### PR TITLE
Made a proprty-based test case more consistent

### DIFF
--- a/tests/Streams.Tests.CSharp/ParStreamsTests.cs
+++ b/tests/Streams.Tests.CSharp/ParStreamsTests.cs
@@ -19,8 +19,8 @@ namespace Nessos.Streams.Tests.CSharp
         {
             Spec.ForAny<int[]>(xs =>
             {
-                var x = xs.AsStream().Select(i => i + 1).ToArray();
-                var y = xs.Select(i => i + 1).ToArray();
+                var x = xs.AsParStream().Select(i => i + 1).ToArray();
+                var y = xs.AsParallel().Select(i => i + 1).ToArray();
                 return x.SequenceEqual(y);
             }).QuickCheckThrowOnFailure();
         }


### PR DESCRIPTION
While reading Stream's property-based tests, I've noticed that a test case in `ParStreamsTests` was using the `AsStream` function. – This pull request changes this particular test case to use `AsParStream` instead.

---

_Please, ignore this pull request if the use of Streams in this particular Parallel Streams property-based test is intentional._
