### PR TITLE
head, tryHead for FSharp and First, FirstOrDefault for CSharp

### DIFF
--- a/src/Streams.CSharp/ParStreams.cs
+++ b/src/Streams.CSharp/ParStreams.cs
@@ -171,6 +171,32 @@ namespace Nessos.Streams.CSharp
             return CSharpProxy.First(stream, predicate);
         }
 
+        /// <summary>Returns the first element in the stream.</summary>
+        /// <param name="stream">The input parallel stream.</param>
+        /// <returns>The first element in the parllel stream.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown if the parallel stream is empty.</exception>
+        public static T First<T>(this ParStream<T> stream)
+        {
+            return CSharpProxy.First(stream);
+        }
+
+        /// <summary>Returns the first element in the stream, or the default value if the stream is empty.</summary>
+        /// <param name="stream">The input parallel stream.</param>
+        /// <returns>The first element in the  parallel stream, or the default value if the parallel stream is empty.</returns>
+        public static T FirstOrDefault<T>(this ParStream<T> stream)
+        {
+            return CSharpProxy.FirstOrDefault(stream);
+        }
+
+        /// <summary>Returns the first element for which the given function returns true. Returns the default value if no such element exists, or the input stream is empty.</summary>
+        /// <param name="predicate">A function to test each source element for a condition.</param>
+        /// <param name="stream">The input parallel stream.</param>
+        /// <returns>The first element for which the predicate returns true, or the default value if no such element exists or the input parallel stream is empty.</returns>
+        public static T FirstOrDefault<T>(this ParStream<T> stream, Func<T, bool> predicate)
+        {
+            return stream.Where(predicate).FirstOrDefault();
+        }
+
         /// <summary>Tests if any element of the stream satisfies the given predicate.</summary>
         /// <param name="predicate">A function to test each source element for a condition.</param>
         /// <param name="stream">The input parallel stream.</param>

--- a/src/Streams.CSharp/ParStreams.cs
+++ b/src/Streams.CSharp/ParStreams.cs
@@ -161,11 +161,11 @@ namespace Nessos.Streams.CSharp
         }
 
 
-        /// <summary>Returns the first element for which the given function returns true. Raises KeyNotFoundException if no such element exists.</summary>
+        /// <summary>Returns the first element for which the given function returns true. Raises InvalidOperationException if no such element exists.</summary>
         /// <param name="predicate">A function to test each source element for a condition.</param>
         /// <param name="stream">The input parallel stream.</param>
         /// <returns>The first element for which the predicate returns true.</returns>
-        /// <exception cref="System.Collections.Generic.KeyNotFoundException">Thrown if the predicate evaluates to false for all the elements of the parallel stream.</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown if the predicate evaluates to false for all the elements of the parallel stream or if the parallel stream is empty.</exception>
         public static TSource First<TSource>(this ParStream<TSource> stream, Func<TSource, bool> predicate)
         {
             return CSharpProxy.First(stream, predicate);

--- a/src/Streams.CSharp/Streams.cs
+++ b/src/Streams.CSharp/Streams.cs
@@ -166,11 +166,11 @@ namespace Nessos.Streams.CSharp
             return Stream.toResizeArray(stream);
         }
 
-        /// <summary>Returns the first element for which the given function returns true. Raises KeyNotFoundException if no such element exists.</summary>
+        /// <summary>Returns the first element for which the given function returns true. Raises InvalidOperationException if no such element exists.</summary>
         /// <param name="predicate">A function to test each source element for a condition.</param>
         /// <param name="stream">The input stream.</param>
         /// <returns>The first element for which the predicate returns true.</returns>
-        /// <exception cref="System.Collections.Generic.KeyNotFoundException">Thrown if the predicate evaluates to false for all the elements of the stream.</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown if the predicate evaluates to false for all the elements of the stream or the stream is empty.</exception>
         public static TSource First<TSource>(this Stream<TSource> stream, Func<TSource, bool> predicate)
         {
             return CSharpProxy.First(stream, predicate);

--- a/src/Streams.CSharp/Streams.cs
+++ b/src/Streams.CSharp/Streams.cs
@@ -176,6 +176,32 @@ namespace Nessos.Streams.CSharp
             return CSharpProxy.First(stream, predicate);
         }
 
+        /// <summary>Returns the first element in the stream.</summary>
+        /// <param name="stream">The input stream.</param>
+        /// <returns>The first element in the stream.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown if the stream is empty.</exception>
+        public static T First<T>(this Stream<T> stream)
+        {
+            return CSharpProxy.First(stream);
+        }
+
+        /// <summary>Returns the first element in the stream, or the default value if the stream is empty.</summary>
+        /// <param name="stream">The input stream.</param>
+        /// <returns>The first element in the stream, or the default value if the input stream is empty.</returns>
+        public static T FirstOrDefault<T>(this Stream<T> stream)
+        {
+            return CSharpProxy.FirstOrDefault(stream);
+        }
+
+        /// <summary>Returns the first element for which the given function returns true. Returns the default value if no such element exists, or the input stream is empty.</summary>
+        /// <param name="predicate">A function to test each source element for a condition.</param>
+        /// <param name="stream">The input stream.</param>
+        /// <returns>The first element for which the predicate returns true, or the default value if no such element exists or the input stream is empty.</returns>
+        public static T FirstOrDefault<T>(this Stream<T> stream, Func<T, bool> predicate)
+        {
+            return stream.Where(predicate).FirstOrDefault();
+        }
+
         /// <summary>Tests if any element of the stream satisfies the given predicate.</summary>
         /// <param name="predicate">A function to test each source element for a condition.</param>
         /// <param name="stream">The input stream.</param>

--- a/src/Streams.Core/CSharpProxy.fs
+++ b/src/Streams.Core/CSharpProxy.fs
@@ -103,10 +103,31 @@ type public CSharpProxy =
         | Some value -> value
         | None -> invalidOp "Stream is empty or no elements satisfy the predicate."
 
+    static member First<'T>(stream : Stream<'T>) =
+        match Stream.tryHead stream with
+        | Some value -> value
+        | None -> invalidOp "Stream is empty"
+
+    static member FirstOrDefault<'T>(stream : Stream<'T>) =
+        match Stream.tryHead stream with
+        | Some value -> value
+        | None -> Unchecked.defaultof<'T>
+
     static member First<'T>(stream : ParStream<'T>, func : Func<'T, bool>)  = 
         match ParStream.tryFind (fun x -> func.Invoke(x)) stream with
         | Some value -> value
         | None -> invalidOp "Stream is empty or no elements satisfy the predicate."
+
+
+    static member First<'T>(stream : ParStream<'T>) =
+        match ParStream.tryHead stream with
+        | Some value -> value
+        | None -> invalidOp "Stream is empty"
+
+    static member FirstOrDefault<'T>(stream : ParStream<'T>) =
+        match ParStream.tryHead stream with
+        | Some value -> value
+        | None -> Unchecked.defaultof<'T>
 
     static member Any<'T>(stream : Stream<'T>, func : Func<'T, bool>)  = 
         Stream.exists (fun x -> func.Invoke(x)) stream

--- a/src/Streams.Core/CSharpProxy.fs
+++ b/src/Streams.Core/CSharpProxy.fs
@@ -99,10 +99,14 @@ type public CSharpProxy =
         ParStream.length stream
 
     static member First<'T>(stream : Stream<'T>, func : Func<'T, bool>)  = 
-        Stream.find (fun x -> func.Invoke(x)) stream
+        match Stream.tryFind (fun x -> func.Invoke(x)) stream with
+        | Some value -> value
+        | None -> invalidOp "Stream is empty or no elements satisfy the predicate."
 
     static member First<'T>(stream : ParStream<'T>, func : Func<'T, bool>)  = 
-        ParStream.find (fun x -> func.Invoke(x)) stream
+        match ParStream.tryFind (fun x -> func.Invoke(x)) stream with
+        | Some value -> value
+        | None -> invalidOp "Stream is empty or no elements satisfy the predicate."
 
     static member Any<'T>(stream : Stream<'T>, func : Func<'T, bool>)  = 
         Stream.exists (fun x -> func.Invoke(x)) stream

--- a/src/Streams.Core/ParStreams.fs
+++ b/src/Streams.Core/ParStreams.fs
@@ -36,7 +36,7 @@ type ParStream<'T> =
     /// The Type of iteration source
     abstract SourceType : SourceType
     /// A flag that indicates that the ordering in the subsequent query operators will be preserved.
-    abstract PreserveOrdering : bool
+    abstract PreserveOrdering: bool
     /// Returns the sequential Stream
     abstract Stream : unit -> Stream<'T>
     /// Applies the given collector to the parallel Stream.
@@ -702,9 +702,37 @@ module ParStream =
     let inline forall (predicate : 'T -> bool) (stream : ParStream<'T>) : bool = 
         not <| exists (fun x -> not <| predicate x) stream
 
+    /// <summary>
+    ///     Returs the first element of the stream.
+    /// </summary
+    /// <param name="stream">The input stream.</param>
+    /// <returns>The first element of the stream, or None if the stream has no elements.</returns>
+    let inline tryHead (stream : ParStream<'T>) : 'T option =
+        let r = stream |> ordered |> take 1 |> toArray
+        if r.Length = 0 then None
+        else Some r.[0]
 
+        // let resultRef = ref Unchecked.defaultof<'T option>
+        // let collector =
+        //     { new Collector<'T, 'T option> with
+        //         member __.DegreeOfParallelism = stream.DegreeOfParallelism
+        //         member __.Iterator() =
+        //             { Index = ref -1;
+        //               Func = (fun value -> resultRef := Some value);
+        //               Cts = new CancellationTokenSource() }
+        //         member __.Result = !resultRef
+        //     }
 
+        // let stream = if stream.PreserveOrdering then (take 1 stream).Stream() |> Stream.toSeq |> ofSeq |> withDegreeOfParallelism stream.DegreeOfParallelism else take 1 stream
+        // stream.Apply collector
 
-
-
-
+    /// <summary>
+    ///     Returs the first element of the stream.
+    /// </summary
+    /// <param name="stream">The input stream.</param>
+    /// <returns>The first element of the stream.</returns>
+    /// <exception cref="System.ArgumentException">Thrown when the stream has no elements.</exception>
+    let inline head (stream : ParStream<'T>) : 'T =
+        match tryHead stream with
+        | Some value -> value
+        | None -> invalidArg "stream" "The stream was empty."

--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -820,3 +820,30 @@ module Stream =
                       Cts = cts }
 
         Stream iter
+
+    /// <summary>
+    ///     Returs the first element of the stream.
+    /// </summary
+    /// <param name="stream">The input stream.</param>
+    /// <returns>The first element of the stream, or None if the stream has no elements.</returns>
+    let inline tryHead (stream : Stream<'T>) : 'T option =
+        let stream' = take 1 stream
+        let (Stream streamf) = stream'
+        let resultRef = ref Unchecked.defaultof<'T option>
+        let { Bulk = bulk; Iterator = _ } = streamf { Complete = (fun () -> ());
+                                                      Cont = (fun value -> resultRef := Some value);
+                                                      Cts = null }
+
+        bulk ()
+        !resultRef
+
+    /// <summary>
+    ///     Returs the first element of the stream.
+    /// </summary
+    /// <param name="stream">The input stream.</param>
+    /// <returns>The first element of the stream.</returns>
+    /// <exception cref="System.ArgumentException">Thrown when the stream has no elements.</exception>
+    let inline head (stream : Stream<'T>) : 'T =
+        match tryHead stream with
+        | Some value -> value
+        | None -> invalidArg "stream" "The stream was empty."

--- a/tests/Streams.Tests.CSharp/ParStreamsTests.cs
+++ b/tests/Streams.Tests.CSharp/ParStreamsTests.cs
@@ -148,7 +148,7 @@ namespace Nessos.Streams.Tests.CSharp
         }
 
         [Test]
-        public void First()
+        public void FirstWithPredicate()
         {
             Spec.ForAny<int[]>(xs =>
             {
@@ -170,6 +170,55 @@ namespace Nessos.Streams.Tests.CSharp
                 {
                     y = -1;
                 }
+                return x == y;
+            }).QuickCheckThrowOnFailure();
+        }
+
+        [Test]
+        public void First()
+        {
+            Spec.ForAny<int[]>(xs =>
+            {
+                var x = 0;
+                try
+                {
+                    x = xs.AsParStream().First();
+                }
+                catch (InvalidOperationException)
+                {
+                    x = -1;
+                }
+                var y = 0;
+                try
+                {
+                    y = xs.AsParallel().First();
+                }
+                catch (InvalidOperationException)
+                {
+                    y = -1;
+                }
+                return x == y;
+            }).QuickCheckThrowOnFailure();
+        }
+
+        [Test]
+        public void FirstOrDefault()
+        {
+            Spec.ForAny<int[]>(xs =>
+            {
+                var x = xs.AsParStream().FirstOrDefault();
+                var y = xs.AsParallel().FirstOrDefault();
+                return x == y;
+            }).QuickCheckThrowOnFailure();
+        }
+
+        [Test]
+        public void FirstOrDefaultWithPredicate()
+        {
+            Spec.ForAny<int[]>(xs =>
+            {
+                var x = xs.AsParStream().FirstOrDefault(i => i % 2 == 0);
+                var y = xs.AsParallel().FirstOrDefault(i => i % 2 == 0);
                 return x == y;
             }).QuickCheckThrowOnFailure();
         }

--- a/tests/Streams.Tests.CSharp/ParStreamsTests.cs
+++ b/tests/Streams.Tests.CSharp/ParStreamsTests.cs
@@ -157,7 +157,7 @@ namespace Nessos.Streams.Tests.CSharp
                 {
                     x = xs.AsParStream().First(i => i == 0);
                 }
-                catch (KeyNotFoundException)
+                catch (InvalidOperationException)
                 {
                     x = -1;
                 }

--- a/tests/Streams.Tests.CSharp/StreamsTests.cs
+++ b/tests/Streams.Tests.CSharp/StreamsTests.cs
@@ -189,7 +189,7 @@ namespace Nessos.Streams.Tests.CSharp
                 {
                     x = xs.AsStream().First(i => i % 2 == 0);
                 }
-                catch (KeyNotFoundException)
+                catch (InvalidOperationException)
                 {
                     x = -1;
                 }

--- a/tests/Streams.Tests.CSharp/StreamsTests.cs
+++ b/tests/Streams.Tests.CSharp/StreamsTests.cs
@@ -180,7 +180,7 @@ namespace Nessos.Streams.Tests.CSharp
         }
 
         [Test]
-        public void First()
+        public void FirstWithPredicate()
         {
             Spec.ForAny<int[]>(xs =>
             {
@@ -202,6 +202,55 @@ namespace Nessos.Streams.Tests.CSharp
                 {
                     y = -1;
                 }
+                return x == y;
+            }).QuickCheckThrowOnFailure();
+        }
+
+        [Test]
+        public void First()
+        {
+            Spec.ForAny<int[]>(xs =>
+            {
+                var x = 0;
+                try
+                {
+                    x = xs.AsStream().First();
+                }
+                catch (InvalidOperationException)
+                {
+                    x = -1;
+                }
+                var y = 0;
+                try
+                {
+                    y = xs.First();
+                }
+                catch (InvalidOperationException)
+                {
+                    y = -1;
+                }
+                return x == y;
+            }).QuickCheckThrowOnFailure();
+        }
+
+        [Test]
+        public void FirstOrDefault()
+        {
+            Spec.ForAny<int[]>(xs =>
+            {
+                var x = xs.AsStream().FirstOrDefault();
+                var y = xs.FirstOrDefault();
+                return x == y;
+            }).QuickCheckThrowOnFailure();
+        }
+
+        [Test]
+        public void FirstOrDefaultWithPredicate()
+        {
+            Spec.ForAny<int[]>(xs =>
+            {
+                var x = xs.AsStream().FirstOrDefault(i => i % 2 == 0);
+                var y = xs.FirstOrDefault(i => i % 2 == 0);
                 return x == y;
             }).QuickCheckThrowOnFailure();
         }

--- a/tests/Streams.Tests/ParStreamsTests.fs
+++ b/tests/Streams.Tests/ParStreamsTests.fs
@@ -298,5 +298,30 @@
                 x = y).QuickCheckThrowOnFailure()
 
 
+        [<Test>]
+        member __.``head`` () =
+            Spec.ForAny<int []>(fun (xs : int []) ->
+                if xs.Length = 0 then
+                    try
+                        ParStream.ofArray xs
+                        |> ParStream.head
+                        |> ignore
+                        Assert.Fail()
+                    with :? System.ArgumentException as exn ->
+                        Assert.AreEqual(exn.ParamName, "stream")
+                else
+                    let x = xs |> ParStream.ofArray |> ParStream.head
+                    let y = xs |> PSeq.ofArray |> PSeq.head
+                    Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
-       
+
+        [<Test>]
+        member __.``tryHead`` () =
+            Spec.ForAny<int []>(fun (xs : int []) ->
+                if xs.Length = 0 then
+                    let r = ParStream.ofArray xs |> ParStream.tryHead
+                    Assert.AreEqual(None, r)
+                else
+                    let x = xs |> ParStream.ofArray |> ParStream.tryHead
+                    let y = xs |> Stream.ofArray |> Stream.tryHead
+                    Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()

--- a/tests/Streams.Tests/ParStreamsTests.fs
+++ b/tests/Streams.Tests/ParStreamsTests.fs
@@ -301,27 +301,18 @@
         [<Test>]
         member __.``head`` () =
             Spec.ForAny<int []>(fun (xs : int []) ->
-                if xs.Length = 0 then
-                    try
-                        ParStream.ofArray xs
-                        |> ParStream.head
-                        |> ignore
-                        Assert.Fail()
-                    with :? System.ArgumentException as exn ->
-                        Assert.AreEqual(exn.ParamName, "stream")
-                else
-                    let x = xs |> ParStream.ofArray |> ParStream.head
-                    let y = xs |> PSeq.ofArray |> PSeq.head
-                    Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+                let x =
+                    try xs |> ParStream.ofArray |> ParStream.head
+                    with :? System.ArgumentException -> -1
+                let y =
+                    try xs |> PSeq.ofArray |> PSeq.head
+                    with :? System.InvalidOperationException -> -1
+                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
 
         [<Test>]
         member __.``tryHead`` () =
             Spec.ForAny<int []>(fun (xs : int []) ->
-                if xs.Length = 0 then
-                    let r = ParStream.ofArray xs |> ParStream.tryHead
-                    Assert.AreEqual(None, r)
-                else
-                    let x = xs |> ParStream.ofArray |> ParStream.tryHead
-                    let y = xs |> Stream.ofArray |> Stream.tryHead
-                    Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+                let x = xs |> ParStream.ofArray |> ParStream.tryHead
+                let y = xs |> Stream.ofArray |> Stream.tryHead
+                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -372,3 +372,25 @@
                 let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
                 let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
                 x = y && !disposed = true).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        member __.``head``() =
+            Spec.ForAny<int []>(fun (xs : int [])->
+                if xs.Length > 0 then
+                    let head = xs.[0]
+                    let head' = xs |> Stream.ofArray |> Stream.head
+                    Assert.AreEqual(head, head')
+                else
+                    try
+                        xs |> Stream.ofArray |> Stream.head |> ignore
+                        Assert.Fail()
+                    with :? System.ArgumentException as exn ->
+                        Assert.AreEqual(exn.ParamName, "stream")).QuickCheckThrowOnFailure()
+
+
+        [<Test>]
+        member __.``tryHead``() =
+            Spec.ForAny<int []>(fun (xs : int [])->
+                let head = xs |> Stream.ofArray |> Stream.tryHead
+                if xs.Length = 0 then Assert.AreEqual(head, None)
+                else Assert.AreEqual(xs.[0], head.Value)).QuickCheckThrowOnFailure()

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -375,22 +375,23 @@
 
         [<Test>]
         member __.``head``() =
-            Spec.ForAny<int []>(fun (xs : int [])->
-                if xs.Length > 0 then
-                    let head = xs.[0]
-                    let head' = xs |> Stream.ofArray |> Stream.head
-                    Assert.AreEqual(head, head')
-                else
-                    try
-                        xs |> Stream.ofArray |> Stream.head |> ignore
-                        Assert.Fail()
-                    with :? System.ArgumentException as exn ->
-                        Assert.AreEqual(exn.ParamName, "stream")).QuickCheckThrowOnFailure()
+            Spec.ForAny<int []>(fun (xs : int []) ->
+                let x =
+                    try xs |> Stream.ofArray |> Stream.head
+                    with :? System.ArgumentException -> -1
 
+                let y =
+                    try xs |> Seq.head
+                    with :? System.ArgumentException -> -1
+
+                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
         [<Test>]
         member __.``tryHead``() =
-            Spec.ForAny<int []>(fun (xs : int [])->
-                let head = xs |> Stream.ofArray |> Stream.tryHead
-                if xs.Length = 0 then Assert.AreEqual(head, None)
-                else Assert.AreEqual(xs.[0], head.Value)).QuickCheckThrowOnFailure()
+            Spec.ForAny<int []>(fun (xs : int []) ->
+                let x = xs |> Stream.ofArray |> Stream.tryHead
+                let y =
+                    try Some (xs |> Seq.head)
+                    with :? System.ArgumentException -> None
+
+                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()


### PR DESCRIPTION
* FSHarp
** Added Stream/ParStream.head, Stream/ParStream.tryHead

* CSharp
** Added Stream/ParStream.First without predicate argument
** Added Stream/ParStream.FirstOrDefault
** Made Stream/ParStream.First throw InvalidOperationException instead of KeyNotFoundException to match the behavior of Linq