### PR TITLE
Use iterator() consistently 

### DIFF
--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -28,9 +28,10 @@ type Context<'T> = {
 }
 
 /// Represents a Stream of values.
-type Stream<'T> (* internal *) (run : Context<'T> -> Iterable) = 
-    member (* internal *) __.Run ctxt = run ctxt
-    member (* internal *) __.RunBulk ctxt = (run ctxt).Bulk()
+type Stream<'T> = 
+    { run : Context<'T> -> Iterable } 
+    member inline (* internal *) stream.Run ctxt = stream.run ctxt
+    member inline (* internal *) stream.RunBulk ctxt = (stream.run ctxt).Bulk()
     override self.ToString() = 
         seq {
             use enumerator = new StreamEnumerator<'T>(self) :> IEnumerator<'T>
@@ -64,7 +65,7 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
                 index <- index + 1
                 if index >= count then
                     count <- 0
-                    if iterable.Iterator.TryAdvance() then
+                    if iterator.TryAdvance() then
                         if count > 0 then 
                             index <- 0
                             true
@@ -86,6 +87,8 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
 /// Provides basic operations on Streams.
 [<RequireQualifiedAccessAttribute>]
 module Stream =
+
+    let inline internal Stream s = { run = s }
 
     /// <summary>The empty stream.</summary>
     /// <returns>An empty stream.</returns>
@@ -136,30 +139,30 @@ module Stream =
                         iterf source.[i]
                 complete ()
                 
-            let tryAdvance = 
+            let iterator() = 
                 let i = ref 0
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun () -> continueFlag := false) |> ignore
-                fun () -> 
-                    if not !continueFlag then
-                        false
-                    else if !i < source.Length then
-                        iterf source.[!i] 
+                { new Iterator with 
+                    member __.TryAdvance() = 
                         if not !continueFlag then
+                            false
+                        else if !i < source.Length then
+                            iterf source.[!i] 
+                            if not !continueFlag then
+                                complete ()
+                            incr i
+                            true
+                        else
+                            continueFlag := false
                             complete ()
-                        incr i
-                        true
-                    else
-                        continueFlag := false
-                        complete ()
-                        true
+                            true
+                    member __.Dispose() = 
+                        if not (cts = null) then cts.Dispose() }
             { new Iterable with 
                  member __.Bulk() = bulk()
-                 member __.Iterator = 
-                     { new Iterator with 
-                          member __.TryAdvance() = tryAdvance()
-                          member __.Dispose() = if not (cts = null) then cts.Dispose() } })
+                 member __.Iterator = iterator() })
 
     /// <summary>Wraps ResizeArray as a stream.</summary>
     /// <param name="source">The input array.</param>
@@ -180,30 +183,32 @@ module Stream =
                         iterf source.[i]
                 complete ()
 
-            let tryAdvance = 
+            let iterator() = 
                 let i = ref 0
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun () -> continueFlag := false) |> ignore
-                fun () -> 
-                    if not !continueFlag then
-                        false
-                    else if !i < source.Count then
-                        iterf source.[!i] 
+                { new Iterator with 
+                    member __.TryAdvance() = 
                         if not !continueFlag then
+                            false
+                        else if !i < source.Count then
+                            iterf source.[!i] 
+                            if not !continueFlag then
+                                complete ()
+                            incr i
+                            true
+                        else
+                            continueFlag := false
                             complete ()
-                        incr i
-                        true
-                    else
-                        continueFlag := false
-                        complete ()
-                        true
+                            true
+
+                    member __.Dispose() = 
+                        if not (cts = null) then cts.Dispose() }
+
             { new Iterable with 
                  member __.Bulk() = bulk()
-                 member __.Iterator = 
-                     { new Iterator with 
-                          member __.TryAdvance() = tryAdvance()
-                          member __.Dispose() = if not (cts = null) then cts.Dispose()  } })
+                 member __.Iterator = iterator() })
 
     /// <summary>Wraps seq as a stream.</summary>
     /// <param name="source">The input seq.</param>
@@ -229,31 +234,30 @@ module Stream =
                         iterf value
                     complete ()
 
-            let iterator = 
+            let iterator() = 
                 let enumerator = source.GetEnumerator()
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun () -> continueFlag := false) |> ignore
-                let tryAdvance () = 
-                    if not !continueFlag then
-                        false
-                    else if enumerator.MoveNext() then
-                        iterf enumerator.Current
-                        if not !continueFlag then
-                            complete ()
-                        true
-                    else
-                        continueFlag := false
-                        complete ()
-                        true
                 { new Iterator with 
-                     member __.TryAdvance() = tryAdvance()
+                     member __.TryAdvance() = 
+                        if not !continueFlag then
+                            false
+                        else if enumerator.MoveNext() then
+                            iterf enumerator.Current
+                            if not !continueFlag then
+                                complete ()
+                            true
+                        else
+                            continueFlag := false
+                            complete ()
+                            true
                      member __.Dispose() = 
                          if not (cts = null) then cts.Dispose() 
                          enumerator.Dispose() }
             { new Iterable with 
                  member __.Bulk() = bulk() 
-                 member __.Iterator = iterator  })
+                 member __.Iterator = iterator()  })
         
     /// <summary>Wraps an IEnumerable as a stream.</summary>
     /// <param name="source">The input seq.</param>
@@ -278,32 +282,30 @@ module Stream =
                         iterf (value :?> 'T)
                     complete ()
 
-            let iterator = 
+            let iterator() = 
                 let enumerator = source.GetEnumerator()
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun () -> continueFlag := false) |> ignore
-                let tryAdvance () = 
-                    if not !continueFlag || not <| enumerator.MoveNext()  then
+                { new Iterator with 
+                     member __.TryAdvance() = 
+                        if not !continueFlag || not <| enumerator.MoveNext()  then
+                            match enumerator with 
+                            | :? System.IDisposable as disposable -> disposable.Dispose()
+                            | _ -> ()
+                            false
+                        else
+                            iterf (enumerator.Current :?> 'T)
+                            true
+                     member __.Dispose() = 
                         match enumerator with 
                         | :? System.IDisposable as disposable -> disposable.Dispose()
                         | _ -> ()
-                        false
-                    else
-                        iterf (enumerator.Current :?> 'T)
-                        true
-                let dispose () = 
-                    match enumerator with 
-                    | :? System.IDisposable as disposable -> disposable.Dispose()
-                    | _ -> ()
-                    complete ()
-                    if not (cts = null) then cts.Dispose() 
-                { new Iterator with 
-                     member __.TryAdvance() = tryAdvance()
-                     member __.Dispose() = dispose() }
+                        complete ()
+                        if not (cts = null) then cts.Dispose()  }
             { new Iterable with 
                 member __.Bulk() = bulk()
-                member __.Iterator = iterator  })
+                member __.Iterator = iterator()  })
 
     /// <summary>Transforms each element of the input stream.</summary>
     /// <param name="f">A function to transform items from the input stream.</param>
@@ -373,18 +375,19 @@ module Stream =
                      source.Run { Complete = complete;
                                   Cont = (fun v -> (if cache.Count - !count = 0 then cache.Add(v)); incr count; iterf v);
                                   Cts = cts }
-                let iterator = iterable.Iterator 
                 let bulk' () = lock cache (fun () -> iterable.Bulk(); cached := Some (ofResizeArray cache))
-
-                //locking each next() seem's overkill
-                let tryAdvance' () = lock cache (fun () -> if iterator.TryAdvance() then true else cached := Some (ofResizeArray cache); false)
-
+                let iterator'() = 
+                    let iterator = iterable.Iterator 
+                    { new Iterator with 
+                        member __.TryAdvance() = 
+                            //locking each next() seem's overkill
+                            lock cache (fun () -> 
+                                if iterator.TryAdvance() then true 
+                                else cached := Some (ofResizeArray cache); false)
+                        member __.Dispose() = iterator.Dispose() } 
                 { new Iterable with 
                     member __.Bulk() = bulk'(); 
-                    member __.Iterator = 
-                        { new Iterator with 
-                            member __.TryAdvance() = tryAdvance'(); 
-                            member __.Dispose() = iterator.Dispose() } })
+                    member __.Iterator = iterator'() })
 
 
     /// <summary>Filters the elements of the input stream.</summary>
@@ -471,7 +474,7 @@ module Stream =
                 for stream in streams do
                     stream.RunBulk { Complete = (fun () -> ()); Cont = iterf; Cts = cts }
                 complete ()
-            let iterator =
+            let iterator() =
                 if Seq.isEmpty streams then 
                     { new Iterator with 
                         member __.TryAdvance() = false; 
@@ -488,28 +491,26 @@ module Stream =
                     let continueFlag = ref true
                     if not (cts = null) then
                         cts.Token.Register(fun _ -> continueFlag := false) |> ignore
-                    let tryAdvance () =
-                        if not !continueFlag then
-                            false
-                        else if enumerator.MoveNext() then
-                            iterf enumerator.Current 
-                            if not !continueFlag then
-                                complete ()
-                            true
-                        else 
-                            continueFlag := false
-                            complete ()
-                            true
-                    let dispose () =
-                        if not (cts = null) then cts.Dispose()
-                        enumerator.Dispose()
                     { new Iterator with 
-                        member __.TryAdvance() = tryAdvance() 
-                        member __.Dispose() = dispose() }
+                        member __.TryAdvance() = 
+                            if not !continueFlag then
+                                false
+                            else if enumerator.MoveNext() then
+                                iterf enumerator.Current 
+                                if not !continueFlag then
+                                    complete ()
+                                true
+                            else 
+                                continueFlag := false
+                                complete ()
+                                true
+                        member __.Dispose() = 
+                            if not (cts = null) then cts.Dispose()
+                            enumerator.Dispose() }
 
             { new Iterable with 
                 member __.Bulk() = bulk()
-                member __.Iterator = iterator })
+                member __.Iterator = iterator() })
 
 
 
@@ -534,35 +535,33 @@ module Stream =
                         next := false
                     ()
                 complete ()
-            let iterator = 
+            let iterator() = 
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun _ -> continueFlag := false) |> ignore
                 let firstEnumerator = new StreamEnumerator<'T>(first) :> IEnumerator<'T>
                 let secondEnumerator = new StreamEnumerator<'S>(second) :> IEnumerator<'S>
-                let tryAdvance () = 
-                    if not !continueFlag then
-                        false
-                    else if firstEnumerator.MoveNext() && secondEnumerator.MoveNext() then
-                        iterf (f firstEnumerator.Current secondEnumerator.Current)
-                        if not !continueFlag then
-                            complete ()
-                        true
-                    else
-                        continueFlag := false
-                        complete ()
-                        true
-                let dispose () = 
-                    if not (cts = null) then
-                        cts.Dispose()
-                    firstEnumerator.Dispose()
-                    secondEnumerator.Dispose()
                 { new Iterator with 
-                    member __.TryAdvance() = tryAdvance() 
-                    member __.Dispose() = dispose() }
+                    member __.TryAdvance() = 
+                        if not !continueFlag then
+                            false
+                        else if firstEnumerator.MoveNext() && secondEnumerator.MoveNext() then
+                            iterf (f firstEnumerator.Current secondEnumerator.Current)
+                            if not !continueFlag then
+                                complete ()
+                            true
+                        else
+                            continueFlag := false
+                            complete ()
+                            true
+                    member __.Dispose() = 
+                        if not (cts = null) then
+                            cts.Dispose()
+                        firstEnumerator.Dispose()
+                        secondEnumerator.Dispose() }
             { new Iterable with 
                 member __.Bulk() = bulk()
-                member __.Iterator = iterator })
+                member __.Iterator = iterator() })
 
 
     /// <summary>Applies a function to each element of the stream, threading an accumulator argument through the computation. If the input function is f and the elements are i0...iN, then this function computes f (... (f s i0)...) iN.</summary>

--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -30,6 +30,7 @@ type (* internal *) Context<'T> = {
 /// Represents a Stream of values.
 type Stream<'T> = 
     { Run : Context<'T> -> Iterable } 
+    member inline internal stream.RunBulk ctxt = (stream.Run ctxt).Bulk()
     override self.ToString() = 
         seq {
             use enumerator = new StreamEnumerator<'T>(self) :> IEnumerator<'T>
@@ -87,8 +88,6 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
 module Stream =
 
     let inline internal Stream f = { Run = f }
-    type Stream<'T> with 
-        member  inline (* internal *) stream.RunBulk ctxt = (stream.Run ctxt).Bulk()
 
     /// <summary>The empty stream.</summary>
     /// <returns>An empty stream.</returns>

--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -29,9 +29,8 @@ type Context<'T> = {
 
 /// Represents a Stream of values.
 type Stream<'T> = 
-    { run : Context<'T> -> Iterable } 
-    member inline (* internal *) stream.Run ctxt = stream.run ctxt
-    member inline (* internal *) stream.RunBulk ctxt = (stream.run ctxt).Bulk()
+    { Run : Context<'T> -> Iterable } 
+    member inline (* internal *) stream.RunBulk ctxt = (stream.Run ctxt).Bulk()
     override self.ToString() = 
         seq {
             use enumerator = new StreamEnumerator<'T>(self) :> IEnumerator<'T>
@@ -88,7 +87,7 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
 [<RequireQualifiedAccessAttribute>]
 module Stream =
 
-    let inline internal Stream s = { run = s }
+    let inline internal Stream f = { Run = f }
 
     /// <summary>The empty stream.</summary>
     /// <returns>An empty stream.</returns>
@@ -316,7 +315,6 @@ module Stream =
             stream.Run { Complete = complete; 
                          Cont = (fun value -> iterf (f value)); 
                          Cts = cts })
-
 
     /// <summary>Transforms each element of the input stream. The integer index passed to the function indicates the index (from 0) of element being transformed.</summary>
     /// <param name="f">A function to transform items and also supplies the current index.</param>

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -1,421 +1,537 @@
-﻿namespace Nessos.Streams.Tests
-    open System.Linq
-    open System.Collections.Generic
-    open FsCheck
-    open FsCheck.Fluent
-    open NUnit.Framework
-    open Nessos.Streams
+﻿#if INTERACTIVE
+#r @"../../bin/Streams.Core.dll"
+//#r @"../../packages/Streams.0.3.0/lib/net45/Streams.Core.dll"
+#r @"../../packages/NUnit.3.0.0-alpha/lib/net45/nunit.framework.dll"
+#r @"../../packages/FsCheck.1.0.1/lib/net45/FSCheck.dll"
+#time "on"
+#else
+namespace Nessos.Streams.Tests
+#endif
+open System.Linq
+open System.Collections.Generic
+open FsCheck
+open FsCheck.Fluent
+open NUnit.Framework
+open Nessos.Streams
 
-    [<TestFixture; Category("Streams.FSharp")>]
-    type ``Streams tests`` () =
+[<TestFixture; Category("Streams.FSharp")>]
+module ``Streams tests``  =
 
-        [<Test>]
-        member __.``ofArray`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map ((+)1) |> Stream.toArray
-                let y = xs |> Seq.map ((+)1) |> Seq.toArray
+    [<Test>]
+    let ``ofArray`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map ((+)1) |> Stream.toArray
+            let y = xs |> Seq.map ((+)1) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``ofResizeArray/toResizeArray`` () =
+        Spec.ForAny<ResizeArray<int>>(fun xs ->
+            let x = xs |> Stream.ofResizeArray |> Stream.map ((+)1) |> Stream.toResizeArray
+            let y = xs |> Seq.map ((+)1) |> Seq.toArray
+            (x.ToArray()) = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``ofSeq`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofSeq |> Stream.map ((+)1) |> Stream.toArray
+            let y = xs |> Seq.map ((+)1) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``toSeq`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
+            let y = xs |> Seq.collect (fun _ -> xs) |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``flatMap/toSeq`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.flatMap (fun x -> [|1..10|] |> Stream.ofArray) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
+            let y = xs |> Seq.collect (fun x -> [|1..10|]) |> Seq.map ((+)1) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``flatMap/find`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq) |> Stream.map ((+)1) |> Stream.find (fun _ -> true)
+            let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id) |> Seq.map ((+)1) |> Seq.find (fun _ -> true)
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``flatMap/take`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq |> Stream.take 10) |> Stream.map ((+)1) |> Stream.take 100 |> Stream.toArray
+            let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id |> Seq.take 10) |> Seq.map ((+)1) |> Seq.take 100 |> Seq.toArray 
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``map`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.toArray
+            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``mapi`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.mapi (fun i n -> i * n) |> Stream.toArray
+            let y = xs |> Seq.mapi (fun i n -> i * n) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``filter`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.toArray
+            let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``choose`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.choose (fun n -> if n % 2 = 0 then Some n else None) |> Stream.toArray
+            let y = xs |> Seq.choose (fun n -> if n % 2 = 0 then Some n else None) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``collect`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.collect (fun n -> [|1..n|] |> Stream.ofArray) |> Stream.toArray
+            let y = xs |> Seq.collect (fun n -> [|1..n|]) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``fold`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.fold (+) 0 
+            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.fold (+) 0 
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``scan`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.scan (+) 0 |> Stream.toArray 
+            let y = xs |> Seq.scan (+) 0 |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()            
+
+    [<Test>]
+    let ``sum`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.sum
+            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.sum
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``length`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.length
+            let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.length
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``sortBy`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map ((+) 1) |> Stream.sortBy id |> Stream.toArray
+            let y = xs |> Seq.map ((+) 1) |> Seq.sortBy id |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``minBy`` () =
+        Spec.ForAny<int[]>(fun xs -> 
+            if Array.isEmpty xs then
+                try let _ = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1) in false
+                with :? System.ArgumentException -> true
+            else
+                let x = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1)
+                let y = xs |> Seq.minBy (fun i -> i + 1)
                 x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``ofResizeArray/toResizeArray`` () =
-            Spec.ForAny<ResizeArray<int>>(fun xs ->
-                let x = xs |> Stream.ofResizeArray |> Stream.map ((+)1) |> Stream.toResizeArray
-                let y = xs |> Seq.map ((+)1) |> Seq.toArray
-                (x.ToArray()) = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``ofSeq`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofSeq |> Stream.map ((+)1) |> Stream.toArray
-                let y = xs |> Seq.map ((+)1) |> Seq.toArray
+    [<Test>]
+    let ``maxBy`` () =
+        Spec.ForAny<int[]>(fun xs -> 
+            if Array.isEmpty xs then 
+                try let _ = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1) in false
+                with :? System.ArgumentException -> true
+            else
+                let x = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1)
+                let y = xs |> Seq.maxBy (fun i -> i + 1)
                 x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``toSeq`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
-                let y = xs |> Seq.collect (fun _ -> xs) |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``countBy`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.countBy (fun i -> i % 5) |> Stream.toArray
+            let y = xs |> Seq.countBy (fun i -> i % 5) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``flatMap/toSeq`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.flatMap (fun x -> [|1..10|] |> Stream.ofArray) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
-                let y = xs |> Seq.collect (fun x -> [|1..10|]) |> Seq.map ((+)1) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``foldBy`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs 
+                    |> Stream.ofArray 
+                    |> Stream.foldBy id (fun ts t -> t :: ts) (fun () -> []) // groupBy implementation
+                    |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
+                    |> Stream.toArray
+            let y = xs  
+                    |> Seq.groupBy id 
+                    |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
+                    |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``flatMap/find`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq) |> Stream.map ((+)1) |> Stream.find (fun _ -> true)
-                let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id) |> Seq.map ((+)1) |> Seq.find (fun _ -> true)
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``groupBy`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs 
+                    |> Stream.ofArray 
+                    |> Stream.groupBy id  
+                    |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
+                    |> Stream.toArray
+            let y = xs  
+                    |> Seq.groupBy id 
+                    |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
+                    |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``flatMap/take`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq |> Stream.take 10) |> Stream.map ((+)1) |> Stream.take 100 |> Stream.toArray
-                let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id |> Seq.take 10) |> Seq.map ((+)1) |> Seq.take 100 |> Seq.toArray 
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``take`` () =
+        Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
+            let n = System.Math.Abs(n) 
+            let x = xs |> Stream.ofArray |> Stream.take n |> Stream.length
+            let y = xs.Take(n).Count()
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``map`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.toArray
-                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``mapi`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.mapi (fun i n -> i * n) |> Stream.toArray
-                let y = xs |> Seq.mapi (fun i n -> i * n) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``filter`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.toArray
-                let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``choose`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.choose (fun n -> if n % 2 = 0 then Some n else None) |> Stream.toArray
-                let y = xs |> Seq.choose (fun n -> if n % 2 = 0 then Some n else None) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``collect`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.collect (fun n -> [|1..n|] |> Stream.ofArray) |> Stream.toArray
-                let y = xs |> Seq.collect (fun n -> [|1..n|]) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``fold`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.fold (+) 0 
-                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.fold (+) 0 
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``scan`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.scan (+) 0 |> Stream.toArray 
-                let y = xs |> Seq.scan (+) 0 |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()            
-
-        [<Test>]
-        member __.``sum`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.sum
-                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.sum
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``length`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.length
-                let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.length
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``sortBy`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map ((+) 1) |> Stream.sortBy id |> Stream.toArray
-                let y = xs |> Seq.map ((+) 1) |> Seq.sortBy id |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``minBy`` () =
-            Spec.ForAny<int[]>(fun xs -> 
-                if Array.isEmpty xs then
-                    try let _ = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1) in false
-                    with :? System.ArgumentException -> true
-                else
-                    let x = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1)
-                    let y = xs |> Seq.minBy (fun i -> i + 1)
-                    x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``maxBy`` () =
-            Spec.ForAny<int[]>(fun xs -> 
-                if Array.isEmpty xs then 
-                    try let _ = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1) in false
-                    with :? System.ArgumentException -> true
-                else
-                    let x = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1)
-                    let y = xs |> Seq.maxBy (fun i -> i + 1)
-                    x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``countBy`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.countBy (fun i -> i % 5) |> Stream.toArray
-                let y = xs |> Seq.countBy (fun i -> i % 5) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``foldBy`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs 
-                        |> Stream.ofArray 
-                        |> Stream.foldBy id (fun ts t -> t :: ts) (fun () -> []) // groupBy implementation
-                        |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
-                        |> Stream.toArray
-                let y = xs  
-                        |> Seq.groupBy id 
-                        |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
-                        |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``groupBy`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs 
-                        |> Stream.ofArray 
-                        |> Stream.groupBy id  
-                        |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
-                        |> Stream.toArray
-                let y = xs  
-                        |> Seq.groupBy id 
-                        |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
-                        |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``take`` () =
-            Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
-                let n = System.Math.Abs(n) 
-                let x = xs |> Stream.ofArray |> Stream.take n |> Stream.length
-                let y = xs.Take(n).Count()
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``take/boundary check`` () =
-            Spec.ForAny<int>(fun (n : int) ->
-                let refs = [| 1; 2; 3; 4 |]
-                let n = System.Math.Abs(n) 
-                let x = [|1..n|]
-                        |> Stream.ofArray
-                        |> Stream.map (fun i -> refs.[i])
-                        |> Stream.take 3
-                        |> Stream.toArray
-                let y = ([|1..n|] |> Seq.map (fun i -> refs.[i])).Take(3).ToArray()
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``take/boundary check`` () =
+        Spec.ForAny<int>(fun (n : int) ->
+            let refs = [| 1; 2; 3; 4 |]
+            let n = System.Math.Abs(n) 
+            let x = [|1..n|]
+                    |> Stream.ofArray
+                    |> Stream.map (fun i -> refs.[i])
+                    |> Stream.take 3
+                    |> Stream.toArray
+            let y = ([|1..n|] |> Seq.map (fun i -> refs.[i])).Take(3).ToArray()
+            x = y).QuickCheckThrowOnFailure()
         
 
 
                 
-        [<Test>]
-        member __.``takeWhile`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let pred = (fun value -> value % 2 = 0)
-                let x = xs |> Stream.ofArray |> Stream.takeWhile pred |> Stream.length
-                let y = xs.TakeWhile(pred).Count()
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``takeWhile`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let pred = (fun value -> value % 2 = 0)
+            let x = xs |> Stream.ofArray |> Stream.takeWhile pred |> Stream.length
+            let y = xs.TakeWhile(pred).Count()
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``collect/take`` () =
-            Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
-                let n = System.Math.Abs(n) 
-                let x = xs |> Stream.ofArray |> Stream.collect(fun x -> xs |> Stream.ofArray |> Stream.take n) |> Stream.length
-                let y = xs.SelectMany(fun x -> xs.Take(n)).Count()
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``collect/take`` () =
+        Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
+            let n = System.Math.Abs(n) 
+            let x = xs |> Stream.ofArray |> Stream.collect(fun x -> xs |> Stream.ofArray |> Stream.take n) |> Stream.length
+            let y = xs.SelectMany(fun x -> xs.Take(n)).Count()
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``skip`` () =
-            Spec.ForAny<int[] * int>(fun (xs, (n : int)) -> 
-                let x = xs |> Stream.ofArray |> Stream.skip n |> Stream.length
-                let y = xs.Skip(n).Count()
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``skip`` () =
+        Spec.ForAny<int[] * int>(fun (xs, (n : int)) -> 
+            let x = xs |> Stream.ofArray |> Stream.skip n |> Stream.length
+            let y = xs.Skip(n).Count()
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``tryFind`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.tryFind (fun n -> n % 2 = 0) 
-                let y = xs |> Seq.tryFind (fun n -> n % 2 = 0) 
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``tryFind`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.tryFind (fun n -> n % 2 = 0) 
+            let y = xs |> Seq.tryFind (fun n -> n % 2 = 0) 
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``find`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = try xs |> Stream.ofArray |> Stream.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
-                let y = try xs |> Seq.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``find`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = try xs |> Stream.ofArray |> Stream.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
+            let y = try xs |> Seq.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``tryPick`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
-                let y = xs |> Seq.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``tryPick`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
+            let y = xs |> Seq.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``pick`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = try xs |> Stream.ofArray |> Stream.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
-                let y = try xs |> Seq.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``pick`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = try xs |> Stream.ofArray |> Stream.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
+            let y = try xs |> Seq.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``exists`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.exists (fun n -> n % 2 = 0) 
-                let y = xs |> Seq.exists (fun n -> n % 2 = 0) 
-                x = y).QuickCheckThrowOnFailure()
-
-
-        [<Test>]
-        member __.``forall`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.forall (fun n -> n % 2 = 0) 
-                let y = xs |> Seq.forall (fun n -> n % 2 = 0) 
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``exists`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.exists (fun n -> n % 2 = 0) 
+            let y = xs |> Seq.exists (fun n -> n % 2 = 0) 
+            x = y).QuickCheckThrowOnFailure()
 
 
-
-        [<Test>]
-        member __.``zipWith`` () =
-            Spec.ForAny<(int[] * int[])>(fun (xs, ys) ->
-                let x = xs |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0) |> Stream.zipWith (fun x y -> x + y) (ys |> Stream.ofArray) |> Stream.toArray
-                let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.zip ys |> Seq.map (fun (x, y) -> x + y) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``empty`` () =
-            //for bulk
-            Assert.AreEqual(0, Stream.empty<int> |> Stream.length)
-            //for next
-            Assert.AreEqual(0, Stream.empty<int> |> Stream.toSeq |> Seq.length)
-
-        [<Test>]
-        member __.``concat`` () =
-            Spec.ForAny<int[][]>(fun xs ->
-                let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toArray
-                let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
-                Assert.AreEqual(x, y)
-                let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toSeq |> Seq.toArray
-                let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
-                Assert.AreEqual(x, y)
-                ).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``forall`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.forall (fun n -> n % 2 = 0) 
+            let y = xs |> Seq.forall (fun n -> n % 2 = 0) 
+            x = y).QuickCheckThrowOnFailure()
 
 
-        [<Test>]
-        member __.``cast`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |>  Stream.cast |> Stream.toArray
-                let y = xs |> Seq.cast |> Seq.toArray
-                Assert.AreEqual(x, y)
-                let x = xs |>  Stream.cast |> Stream.toSeq |> Seq.length
-                let y = xs |> Seq.cast |> Seq.length
-                Assert.AreEqual(x, y)
-                ).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``cache``() =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.cache |> Stream.toArray
-                let y = xs |> Seq.cache |> Seq.toArray
-                Assert.AreEqual(x, y)
-                let cached = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-                let cachedSeq = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
-                let x' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
-                let x'' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
-                Assert.AreEqual(x', x'')
-                let y' = cachedSeq |> Seq.map (fun x -> x + 1) |> Seq.toArray
-                Assert.AreEqual(x', y')
+    [<Test>]
+    let ``zipWith`` () =
+        Spec.ForAny<(int[] * int[])>(fun (xs, ys) ->
+            let x = xs |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0) |> Stream.zipWith (fun x y -> x + y) (ys |> Stream.ofArray) |> Stream.toArray
+            let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.zip ys |> Seq.map (fun (x, y) -> x + y) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
 
-                let cached' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-                let cachedSeq' = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+    [<Test>]
+    let ``empty`` () =
+        //for bulk
+        Assert.AreEqual(0, Stream.empty<int> |> Stream.length)
+        //for next
+        Assert.AreEqual(0, Stream.empty<int> |> Stream.toSeq |> Seq.length)
 
-                let count = ref 0
-                try cached' |> Stream.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
-                try cachedSeq' |> Seq.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
-                let x''' = cached' |> Stream.map (fun x -> x + 1) |> Stream.toArray
-                let y''' = cachedSeq' |> Seq.map (fun x -> x + 1) |> Seq.toArray
-                Assert.AreEqual(x''', y''')
-                Assert.AreEqual(x''', x'')
-
-                let cached'' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-                let x4 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toSeq |> Seq.toArray
-                let x5 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toArray
-                Assert.AreEqual(x4, x5)
-                ).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``groupUntil``() =
-            Spec.ForAny<int []>(fun xs ->
-                // push-based tests
-                let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toArray |> Array.concat
-                Assert.AreEqual(xs, ys)
-                let failedPredicates = ref 0
-                let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toArray |> Seq.concat |> Seq.length
-                Assert.AreEqual(xs.Length, ys + !failedPredicates)
-                // pull-based tests
-                let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toSeq |> Array.concat
-                Assert.AreEqual(xs, ys)
-                let failedPredicates = ref 0
-                let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toSeq |> Seq.concat |> Seq.length
-                Assert.AreEqual(xs.Length, ys + !failedPredicates)
+    [<Test>]
+    let ``concat`` () =
+        Spec.ForAny<int[][]>(fun xs ->
+            let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toArray
+            let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
+            Assert.AreEqual(x, y)
+            let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toSeq |> Seq.toArray
+            let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
+            Assert.AreEqual(x, y)
             ).QuickCheckThrowOnFailure()
 
 
-        [<Test>]
-        member __.``seq/dispose``() =
-            let disposed = ref false
-            let testEnumerator (array : int []) = 
-                disposed := false
-                let index = ref -1
-                {   new IEnumerator<int> with
-                        member self.Current = array.[!index]
-                    interface System.Collections.IEnumerator with  
-                        member self.Current = box array.[!index]
-                        member self.MoveNext() = 
-                            incr index
-                            if !index >= array.Length then false else true
-                        member self.Reset() = index := -1 
-                    interface System.IDisposable with  
-                        member self.Dispose() = disposed := true }
-            let testEnumerable (array : int []) = 
-                {   new IEnumerable<int> with
-                        member self.GetEnumerator() = testEnumerator array
-                    interface System.Collections.IEnumerable with
-                        member self.GetEnumerator() = testEnumerator array :> _ }
-            Spec.ForAny<int []>(fun xs -> 
-                let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
-                let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
-                x = y && !disposed = true).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``cast`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |>  Stream.cast |> Stream.toArray
+            let y = xs |> Seq.cast |> Seq.toArray
+            Assert.AreEqual(x, y)
+            let x = xs |>  Stream.cast |> Stream.toSeq |> Seq.length
+            let y = xs |> Seq.cast |> Seq.length
+            Assert.AreEqual(x, y)
+            ).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``head``() =
-            Spec.ForAny<int []>(fun (xs : int []) ->
-                let x =
-                    try xs |> Stream.ofArray |> Stream.head
-                    with :? System.ArgumentException -> -1
+    [<Test>]
+    let ``cache``() =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.cache |> Stream.toArray
+            let y = xs |> Seq.cache |> Seq.toArray
+            Assert.AreEqual(x, y)
+            let cached = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+            let cachedSeq = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+            let x' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
+            let x'' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
+            Assert.AreEqual(x', x'')
+            let y' = cachedSeq |> Seq.map (fun x -> x + 1) |> Seq.toArray
+            Assert.AreEqual(x', y')
 
-                let y =
-                    try xs |> Seq.head
-                    with :? System.ArgumentException -> -1
+            let cached' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+            let cachedSeq' = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
 
-                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+            let count = ref 0
+            try cached' |> Stream.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
+            try cachedSeq' |> Seq.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
+            let x''' = cached' |> Stream.map (fun x -> x + 1) |> Stream.toArray
+            let y''' = cachedSeq' |> Seq.map (fun x -> x + 1) |> Seq.toArray
+            Assert.AreEqual(x''', y''')
+            Assert.AreEqual(x''', x'')
 
-        [<Test>]
-        member __.``tryHead``() =
-            Spec.ForAny<int []>(fun (xs : int []) ->
-                let x = xs |> Stream.ofArray |> Stream.tryHead
-                let y =
-                    try Some (xs |> Seq.head)
-                    with :? System.ArgumentException -> None
+            let cached'' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+            let x4 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toSeq |> Seq.toArray
+            let x5 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toArray
+            Assert.AreEqual(x4, x5)
+            ).QuickCheckThrowOnFailure()
 
-                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``groupUntil``() =
+        Spec.ForAny<int []>(fun xs ->
+            // push-based tests
+            let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toArray |> Array.concat
+            Assert.AreEqual(xs, ys)
+            let failedPredicates = ref 0
+            let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toArray |> Seq.concat |> Seq.length
+            Assert.AreEqual(xs.Length, ys + !failedPredicates)
+            // pull-based tests
+            let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toSeq |> Array.concat
+            Assert.AreEqual(xs, ys)
+            let failedPredicates = ref 0
+            let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toSeq |> Seq.concat |> Seq.length
+            Assert.AreEqual(xs.Length, ys + !failedPredicates)
+        ).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``isEmpty``() =
-            Spec.ForAny<int []>(fun (xs : int  []) ->
-                let x = xs |> Stream.ofArray |> Stream.isEmpty
-                let y = xs |> Array.isEmpty
 
-                Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``seq/dispose``() =
+        let disposed = ref false
+        let testEnumerator (array : int []) = 
+            disposed := false
+            let index = ref -1
+            {   new IEnumerator<int> with
+                    member self.Current = array.[!index]
+                interface System.Collections.IEnumerator with  
+                    member self.Current = box array.[!index]
+                    member self.MoveNext() = 
+                        incr index
+                        if !index >= array.Length then false else true
+                    member self.Reset() = index := -1 
+                interface System.IDisposable with  
+                    member self.Dispose() = disposed := true }
+        let testEnumerable (array : int []) = 
+            {   new IEnumerable<int> with
+                    member self.GetEnumerator() = testEnumerator array
+                interface System.Collections.IEnumerable with
+                    member self.GetEnumerator() = testEnumerator array :> _ }
+        Spec.ForAny<int []>(fun xs -> 
+            let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
+            let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
+            x = y && !disposed = true).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``head``() =
+        Spec.ForAny<int []>(fun (xs : int []) ->
+            let x =
+                try xs |> Stream.ofArray |> Stream.head
+                with :? System.ArgumentException -> -1
+
+            let y =
+                try xs |> Seq.head
+                with :? System.ArgumentException -> -1
+
+            Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``tryHead``() =
+        Spec.ForAny<int []>(fun (xs : int []) ->
+            let x = xs |> Stream.ofArray |> Stream.tryHead
+            let y =
+                try Some (xs |> Seq.head)
+                with :? System.ArgumentException -> None
+
+            Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+
+(*
+    [<Test>]
+    let ``isEmpty``() =
+        Spec.ForAny<int []>(fun (xs : int  []) ->
+            let x = xs |> Stream.ofArray |> Stream.isEmpty
+            let y = xs |> Array.isEmpty
+
+            Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
+*)
+
+module PerfTests = 
+  let AdhocPerformanceTest() = 
+
+    let xs = Array.init 1000000 id
+
+    let runSeq() =
+        xs
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.filter (fun x -> x % 2 = 0)
+        |> Seq.length
+
+    let runList() =
+        xs
+        |> List.ofArray
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.filter (fun x -> x % 2 = 0)
+        |> List.length
+
+ 
+    let runArray() =
+        xs
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.filter (fun x -> x % 2 = 0)
+        |> Array.length
+
+    let runStream() =
+     for i in 0 .. 100 do
+        xs 
+        |> Stream.ofArray
+        |> Stream.take 1000000
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.filter (fun x -> x % 2 = 0)
+        |> Stream.length
+        |> ignore
+
+    runSeq() |> ignore
+    runList() |> ignore
+    runStream() |> ignore
+      //0.3.0: 
+      // Real: 00:00:03.696, CPU: 00:00:03.671, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.519, CPU: 00:00:03.515, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:04.427, CPU: 00:00:04.406, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.735, CPU: 00:00:02.718, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.358, CPU: 00:00:03.359, GC gen0: 0, gen1: 0, gen2: 0
+      // New (with inlining)
+      // Real: 00:00:03.893, CPU: 00:00:03.906, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.672, CPU: 00:00:02.625, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.298, CPU: 00:00:03.296, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.859, CPU: 00:00:02.859, GC gen0: 1, gen1: 0, gen2: 0
+      // Real: 00:00:03.102, CPU: 00:00:03.093, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:04.127, CPU: 00:00:04.093, GC gen0: 0, gen1: 0, gen2: 0
+      // New (without inlining)
+      // Real: 00:00:17.211, CPU: 00:00:16.937, GC gen0: 1, gen1: 0, gen2: 0
+      // Real: 00:00:17.750, CPU: 00:00:17.687, GC gen0: 0, gen1: 0, gen2: 0
+      // New (with inlining and Stream as record)
+      // Real: 00:00:02.411, CPU: 00:00:02.390, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.487, CPU: 00:00:02.468, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.428, CPU: 00:00:02.437, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.465, CPU: 00:00:02.468, GC gen0: 1, gen1: 0, gen2: 0
+      // Real: 00:00:02.495, CPU: 00:00:02.484, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.853, CPU: 00:00:02.859, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.276, CPU: 00:00:03.234, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.757, CPU: 00:00:02.718, GC gen0: 0, gen1: 0, gen2: 0
+
+
+
+    runArray() |> ignore
+ 
+

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -17,418 +17,416 @@ open Nessos.Streams
 [<TestFixture; Category("Streams.FSharp")>]
 module ``Streams tests``  =
 
-    [<Test>]
-    let ``ofArray`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map ((+)1) |> Stream.toArray
-            let y = xs |> Seq.map ((+)1) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``ofResizeArray/toResizeArray`` () =
-        Spec.ForAny<ResizeArray<int>>(fun xs ->
-            let x = xs |> Stream.ofResizeArray |> Stream.map ((+)1) |> Stream.toResizeArray
-            let y = xs |> Seq.map ((+)1) |> Seq.toArray
-            (x.ToArray()) = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``ofSeq`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofSeq |> Stream.map ((+)1) |> Stream.toArray
-            let y = xs |> Seq.map ((+)1) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``toSeq`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
-            let y = xs |> Seq.collect (fun _ -> xs) |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``flatMap/toSeq`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.flatMap (fun x -> [|1..10|] |> Stream.ofArray) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
-            let y = xs |> Seq.collect (fun x -> [|1..10|]) |> Seq.map ((+)1) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``flatMap/find`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq) |> Stream.map ((+)1) |> Stream.find (fun _ -> true)
-            let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id) |> Seq.map ((+)1) |> Seq.find (fun _ -> true)
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``flatMap/take`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq |> Stream.take 10) |> Stream.map ((+)1) |> Stream.take 100 |> Stream.toArray
-            let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id |> Seq.take 10) |> Seq.map ((+)1) |> Seq.take 100 |> Seq.toArray 
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``map`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.toArray
-            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``mapi`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.mapi (fun i n -> i * n) |> Stream.toArray
-            let y = xs |> Seq.mapi (fun i n -> i * n) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``filter`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.toArray
-            let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``choose`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.choose (fun n -> if n % 2 = 0 then Some n else None) |> Stream.toArray
-            let y = xs |> Seq.choose (fun n -> if n % 2 = 0 then Some n else None) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``collect`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.collect (fun n -> [|1..n|] |> Stream.ofArray) |> Stream.toArray
-            let y = xs |> Seq.collect (fun n -> [|1..n|]) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``fold`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.fold (+) 0 
-            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.fold (+) 0 
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``scan`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.scan (+) 0 |> Stream.toArray 
-            let y = xs |> Seq.scan (+) 0 |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()            
-
-    [<Test>]
-    let ``sum`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.sum
-            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.sum
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``length`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.length
-            let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.length
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``sortBy`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map ((+) 1) |> Stream.sortBy id |> Stream.toArray
-            let y = xs |> Seq.map ((+) 1) |> Seq.sortBy id |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``minBy`` () =
-        Spec.ForAny<int[]>(fun xs -> 
-            if Array.isEmpty xs then
-                try let _ = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1) in false
-                with :? System.ArgumentException -> true
-            else
-                let x = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1)
-                let y = xs |> Seq.minBy (fun i -> i + 1)
+        [<Test>]
+        let ``ofArray`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map ((+)1) |> Stream.toArray
+                let y = xs |> Seq.map ((+)1) |> Seq.toArray
                 x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``maxBy`` () =
-        Spec.ForAny<int[]>(fun xs -> 
-            if Array.isEmpty xs then 
-                try let _ = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1) in false
-                with :? System.ArgumentException -> true
-            else
-                let x = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1)
-                let y = xs |> Seq.maxBy (fun i -> i + 1)
+        [<Test>]
+        let ``ofResizeArray/toResizeArray`` () =
+            Spec.ForAny<ResizeArray<int>>(fun xs ->
+                let x = xs |> Stream.ofResizeArray |> Stream.map ((+)1) |> Stream.toResizeArray
+                let y = xs |> Seq.map ((+)1) |> Seq.toArray
+                (x.ToArray()) = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``ofSeq`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofSeq |> Stream.map ((+)1) |> Stream.toArray
+                let y = xs |> Seq.map ((+)1) |> Seq.toArray
                 x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``countBy`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.countBy (fun i -> i % 5) |> Stream.toArray
-            let y = xs |> Seq.countBy (fun i -> i % 5) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``toSeq`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
+                let y = xs |> Seq.collect (fun _ -> xs) |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``foldBy`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs 
-                    |> Stream.ofArray 
-                    |> Stream.foldBy id (fun ts t -> t :: ts) (fun () -> []) // groupBy implementation
-                    |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
-                    |> Stream.toArray
-            let y = xs  
-                    |> Seq.groupBy id 
-                    |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
-                    |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``flatMap/toSeq`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.flatMap (fun x -> [|1..10|] |> Stream.ofArray) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
+                let y = xs |> Seq.collect (fun x -> [|1..10|]) |> Seq.map ((+)1) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``groupBy`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs 
-                    |> Stream.ofArray 
-                    |> Stream.groupBy id  
-                    |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
-                    |> Stream.toArray
-            let y = xs  
-                    |> Seq.groupBy id 
-                    |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
-                    |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``flatMap/find`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq) |> Stream.map ((+)1) |> Stream.find (fun _ -> true)
+                let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id) |> Seq.map ((+)1) |> Seq.find (fun _ -> true)
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``take`` () =
-        Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
-            let n = System.Math.Abs(n) 
-            let x = xs |> Stream.ofArray |> Stream.take n |> Stream.length
-            let y = xs.Take(n).Count()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``flatMap/take`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq |> Stream.take 10) |> Stream.map ((+)1) |> Stream.take 100 |> Stream.toArray
+                let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id |> Seq.take 10) |> Seq.map ((+)1) |> Seq.take 100 |> Seq.toArray 
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``take/boundary check`` () =
-        Spec.ForAny<int>(fun (n : int) ->
-            let refs = [| 1; 2; 3; 4 |]
-            let n = System.Math.Abs(n) 
-            let x = [|1..n|]
-                    |> Stream.ofArray
-                    |> Stream.map (fun i -> refs.[i])
-                    |> Stream.take 3
-                    |> Stream.toArray
-            let y = ([|1..n|] |> Seq.map (fun i -> refs.[i])).Take(3).ToArray()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``map`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.toArray
+                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``mapi`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.mapi (fun i n -> i * n) |> Stream.toArray
+                let y = xs |> Seq.mapi (fun i n -> i * n) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``filter`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.toArray
+                let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``choose`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.choose (fun n -> if n % 2 = 0 then Some n else None) |> Stream.toArray
+                let y = xs |> Seq.choose (fun n -> if n % 2 = 0 then Some n else None) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``collect`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.collect (fun n -> [|1..n|] |> Stream.ofArray) |> Stream.toArray
+                let y = xs |> Seq.collect (fun n -> [|1..n|]) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``fold`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.fold (+) 0 
+                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.fold (+) 0 
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``scan`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.scan (+) 0 |> Stream.toArray 
+                let y = xs |> Seq.scan (+) 0 |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()            
+
+        [<Test>]
+        let ``sum`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.sum
+                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.sum
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``length`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.length
+                let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.length
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``sortBy`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map ((+) 1) |> Stream.sortBy id |> Stream.toArray
+                let y = xs |> Seq.map ((+) 1) |> Seq.sortBy id |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``minBy`` () =
+            Spec.ForAny<int[]>(fun xs -> 
+                if Array.isEmpty xs then
+                    try let _ = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1) in false
+                    with :? System.ArgumentException -> true
+                else
+                    let x = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1)
+                    let y = xs |> Seq.minBy (fun i -> i + 1)
+                    x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``maxBy`` () =
+            Spec.ForAny<int[]>(fun xs -> 
+                if Array.isEmpty xs then 
+                    try let _ = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1) in false
+                    with :? System.ArgumentException -> true
+                else
+                    let x = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1)
+                    let y = xs |> Seq.maxBy (fun i -> i + 1)
+                    x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``countBy`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.countBy (fun i -> i % 5) |> Stream.toArray
+                let y = xs |> Seq.countBy (fun i -> i % 5) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``foldBy`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs 
+                        |> Stream.ofArray 
+                        |> Stream.foldBy id (fun ts t -> t :: ts) (fun () -> []) // groupBy implementation
+                        |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
+                        |> Stream.toArray
+                let y = xs  
+                        |> Seq.groupBy id 
+                        |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
+                        |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``groupBy`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs 
+                        |> Stream.ofArray 
+                        |> Stream.groupBy id  
+                        |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
+                        |> Stream.toArray
+                let y = xs  
+                        |> Seq.groupBy id 
+                        |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
+                        |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``take`` () =
+            Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
+                let n = System.Math.Abs(n) 
+                let x = xs |> Stream.ofArray |> Stream.take n |> Stream.length
+                let y = xs.Take(n).Count()
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``take/boundary check`` () =
+            Spec.ForAny<int>(fun (n : int) ->
+                let refs = [| 1; 2; 3; 4 |]
+                let n = System.Math.Abs(n) 
+                let x = [|1..n|]
+                        |> Stream.ofArray
+                        |> Stream.map (fun i -> refs.[i])
+                        |> Stream.take 3
+                        |> Stream.toArray
+                let y = ([|1..n|] |> Seq.map (fun i -> refs.[i])).Take(3).ToArray()
+                x = y).QuickCheckThrowOnFailure()
         
 
 
                 
-    [<Test>]
-    let ``takeWhile`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let pred = (fun value -> value % 2 = 0)
-            let x = xs |> Stream.ofArray |> Stream.takeWhile pred |> Stream.length
-            let y = xs.TakeWhile(pred).Count()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``takeWhile`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let pred = (fun value -> value % 2 = 0)
+                let x = xs |> Stream.ofArray |> Stream.takeWhile pred |> Stream.length
+                let y = xs.TakeWhile(pred).Count()
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``collect/take`` () =
-        Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
-            let n = System.Math.Abs(n) 
-            let x = xs |> Stream.ofArray |> Stream.collect(fun x -> xs |> Stream.ofArray |> Stream.take n) |> Stream.length
-            let y = xs.SelectMany(fun x -> xs.Take(n)).Count()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``collect/take`` () =
+            Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
+                let n = System.Math.Abs(n) 
+                let x = xs |> Stream.ofArray |> Stream.collect(fun x -> xs |> Stream.ofArray |> Stream.take n) |> Stream.length
+                let y = xs.SelectMany(fun x -> xs.Take(n)).Count()
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``skip`` () =
-        Spec.ForAny<int[] * int>(fun (xs, (n : int)) -> 
-            let x = xs |> Stream.ofArray |> Stream.skip n |> Stream.length
-            let y = xs.Skip(n).Count()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``skip`` () =
+            Spec.ForAny<int[] * int>(fun (xs, (n : int)) -> 
+                let x = xs |> Stream.ofArray |> Stream.skip n |> Stream.length
+                let y = xs.Skip(n).Count()
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``tryFind`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.tryFind (fun n -> n % 2 = 0) 
-            let y = xs |> Seq.tryFind (fun n -> n % 2 = 0) 
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``tryFind`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.tryFind (fun n -> n % 2 = 0) 
+                let y = xs |> Seq.tryFind (fun n -> n % 2 = 0) 
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``find`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = try xs |> Stream.ofArray |> Stream.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
-            let y = try xs |> Seq.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``find`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = try xs |> Stream.ofArray |> Stream.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
+                let y = try xs |> Seq.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``tryPick`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
-            let y = xs |> Seq.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``tryPick`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
+                let y = xs |> Seq.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``pick`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = try xs |> Stream.ofArray |> Stream.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
-            let y = try xs |> Seq.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``pick`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = try xs |> Stream.ofArray |> Stream.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
+                let y = try xs |> Seq.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``exists`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.exists (fun n -> n % 2 = 0) 
-            let y = xs |> Seq.exists (fun n -> n % 2 = 0) 
-            x = y).QuickCheckThrowOnFailure()
-
-
-    [<Test>]
-    let ``forall`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.forall (fun n -> n % 2 = 0) 
-            let y = xs |> Seq.forall (fun n -> n % 2 = 0) 
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``exists`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.exists (fun n -> n % 2 = 0) 
+                let y = xs |> Seq.exists (fun n -> n % 2 = 0) 
+                x = y).QuickCheckThrowOnFailure()
 
 
+        [<Test>]
+        let ``forall`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.forall (fun n -> n % 2 = 0) 
+                let y = xs |> Seq.forall (fun n -> n % 2 = 0) 
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``zipWith`` () =
-        Spec.ForAny<(int[] * int[])>(fun (xs, ys) ->
-            let x = xs |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0) |> Stream.zipWith (fun x y -> x + y) (ys |> Stream.ofArray) |> Stream.toArray
-            let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.zip ys |> Seq.map (fun (x, y) -> x + y) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``empty`` () =
-        //for bulk
-        Assert.AreEqual(0, Stream.empty<int> |> Stream.length)
-        //for next
-        Assert.AreEqual(0, Stream.empty<int> |> Stream.toSeq |> Seq.length)
 
-    [<Test>]
-    let ``concat`` () =
-        Spec.ForAny<int[][]>(fun xs ->
-            let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toArray
-            let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
-            Assert.AreEqual(x, y)
-            let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toSeq |> Seq.toArray
-            let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
-            Assert.AreEqual(x, y)
+        [<Test>]
+        let ``zipWith`` () =
+            Spec.ForAny<(int[] * int[])>(fun (xs, ys) ->
+                let x = xs |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0) |> Stream.zipWith (fun x y -> x + y) (ys |> Stream.ofArray) |> Stream.toArray
+                let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.zip ys |> Seq.map (fun (x, y) -> x + y) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``empty`` () =
+            //for bulk
+            Assert.AreEqual(0, Stream.empty<int> |> Stream.length)
+            //for next
+            Assert.AreEqual(0, Stream.empty<int> |> Stream.toSeq |> Seq.length)
+
+        [<Test>]
+        let ``concat`` () =
+            Spec.ForAny<int[][]>(fun xs ->
+                let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toArray
+                let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
+                Assert.AreEqual(x, y)
+                let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toSeq |> Seq.toArray
+                let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
+                Assert.AreEqual(x, y)
+                ).QuickCheckThrowOnFailure()
+
+
+        [<Test>]
+        let ``cast`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |>  Stream.cast |> Stream.toArray
+                let y = xs |> Seq.cast |> Seq.toArray
+                Assert.AreEqual(x, y)
+                let x = xs |>  Stream.cast |> Stream.toSeq |> Seq.length
+                let y = xs |> Seq.cast |> Seq.length
+                Assert.AreEqual(x, y)
+                ).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``cache``() =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.cache |> Stream.toArray
+                let y = xs |> Seq.cache |> Seq.toArray
+                Assert.AreEqual(x, y)
+                let cached = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+                let cachedSeq = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+                let x' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
+                let x'' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
+                Assert.AreEqual(x', x'')
+                let y' = cachedSeq |> Seq.map (fun x -> x + 1) |> Seq.toArray
+                Assert.AreEqual(x', y')
+
+                let cached' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+                let cachedSeq' = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+
+                let count = ref 0
+                try cached' |> Stream.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
+                try cachedSeq' |> Seq.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
+                let x''' = cached' |> Stream.map (fun x -> x + 1) |> Stream.toArray
+                let y''' = cachedSeq' |> Seq.map (fun x -> x + 1) |> Seq.toArray
+                Assert.AreEqual(x''', y''')
+                Assert.AreEqual(x''', x'')
+
+                let cached'' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+                let x4 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toSeq |> Seq.toArray
+                let x5 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toArray
+                Assert.AreEqual(x4, x5)
+                ).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``groupUntil``() =
+            Spec.ForAny<int []>(fun xs ->
+                // push-based tests
+                let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toArray |> Array.concat
+                Assert.AreEqual(xs, ys)
+                let failedPredicates = ref 0
+                let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toArray |> Seq.concat |> Seq.length
+                Assert.AreEqual(xs.Length, ys + !failedPredicates)
+                // pull-based tests
+                let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toSeq |> Array.concat
+                Assert.AreEqual(xs, ys)
+                let failedPredicates = ref 0
+                let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toSeq |> Seq.concat |> Seq.length
+                Assert.AreEqual(xs.Length, ys + !failedPredicates)
             ).QuickCheckThrowOnFailure()
 
 
-    [<Test>]
-    let ``cast`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |>  Stream.cast |> Stream.toArray
-            let y = xs |> Seq.cast |> Seq.toArray
-            Assert.AreEqual(x, y)
-            let x = xs |>  Stream.cast |> Stream.toSeq |> Seq.length
-            let y = xs |> Seq.cast |> Seq.length
-            Assert.AreEqual(x, y)
-            ).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``seq/dispose``() =
+            let disposed = ref false
+            let testEnumerator (array : int []) = 
+                disposed := false
+                let index = ref -1
+                {   new IEnumerator<int> with
+                        member self.Current = array.[!index]
+                    interface System.Collections.IEnumerator with  
+                        member self.Current = box array.[!index]
+                        member self.MoveNext() = 
+                            incr index
+                            if !index >= array.Length then false else true
+                        member self.Reset() = index := -1 
+                    interface System.IDisposable with  
+                        member self.Dispose() = disposed := true }
+            let testEnumerable (array : int []) = 
+                {   new IEnumerable<int> with
+                        member self.GetEnumerator() = testEnumerator array
+                    interface System.Collections.IEnumerable with
+                        member self.GetEnumerator() = testEnumerator array :> _ }
+            Spec.ForAny<int []>(fun xs -> 
+                let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
+                let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
+                x = y && !disposed = true).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``cache``() =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.cache |> Stream.toArray
-            let y = xs |> Seq.cache |> Seq.toArray
-            Assert.AreEqual(x, y)
-            let cached = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-            let cachedSeq = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
-            let x' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
-            let x'' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
-            Assert.AreEqual(x', x'')
-            let y' = cachedSeq |> Seq.map (fun x -> x + 1) |> Seq.toArray
-            Assert.AreEqual(x', y')
+        [<Test>]
+        let ``head``() =
+            Spec.ForAny<int []>(fun (xs : int []) ->
+                let x =
+                    try xs |> Stream.ofArray |> Stream.head
+                    with :? System.ArgumentException -> -1
 
-            let cached' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-            let cachedSeq' = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+                let y =
+                    try xs |> Seq.head
+                    with :? System.ArgumentException -> -1
 
-            let count = ref 0
-            try cached' |> Stream.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
-            try cachedSeq' |> Seq.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
-            let x''' = cached' |> Stream.map (fun x -> x + 1) |> Stream.toArray
-            let y''' = cachedSeq' |> Seq.map (fun x -> x + 1) |> Seq.toArray
-            Assert.AreEqual(x''', y''')
-            Assert.AreEqual(x''', x'')
+                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
-            let cached'' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-            let x4 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toSeq |> Seq.toArray
-            let x5 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toArray
-            Assert.AreEqual(x4, x5)
-            ).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``tryHead``() =
+            Spec.ForAny<int []>(fun (xs : int []) ->
+                let x = xs |> Stream.ofArray |> Stream.tryHead
+                let y =
+                    try Some (xs |> Seq.head)
+                    with :? System.ArgumentException -> None
 
-    [<Test>]
-    let ``groupUntil``() =
-        Spec.ForAny<int []>(fun xs ->
-            // push-based tests
-            let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toArray |> Array.concat
-            Assert.AreEqual(xs, ys)
-            let failedPredicates = ref 0
-            let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toArray |> Seq.concat |> Seq.length
-            Assert.AreEqual(xs.Length, ys + !failedPredicates)
-            // pull-based tests
-            let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toSeq |> Array.concat
-            Assert.AreEqual(xs, ys)
-            let failedPredicates = ref 0
-            let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toSeq |> Seq.concat |> Seq.length
-            Assert.AreEqual(xs.Length, ys + !failedPredicates)
-        ).QuickCheckThrowOnFailure()
+                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
+        [<Test>]
+        let ``isEmpty``() =
+            Spec.ForAny<int []>(fun (xs : int  []) ->
+                let x = xs |> Stream.ofArray |> Stream.isEmpty
+                let y = xs |> Array.isEmpty
 
-    [<Test>]
-    let ``seq/dispose``() =
-        let disposed = ref false
-        let testEnumerator (array : int []) = 
-            disposed := false
-            let index = ref -1
-            {   new IEnumerator<int> with
-                    member self.Current = array.[!index]
-                interface System.Collections.IEnumerator with  
-                    member self.Current = box array.[!index]
-                    member self.MoveNext() = 
-                        incr index
-                        if !index >= array.Length then false else true
-                    member self.Reset() = index := -1 
-                interface System.IDisposable with  
-                    member self.Dispose() = disposed := true }
-        let testEnumerable (array : int []) = 
-            {   new IEnumerable<int> with
-                    member self.GetEnumerator() = testEnumerator array
-                interface System.Collections.IEnumerable with
-                    member self.GetEnumerator() = testEnumerator array :> _ }
-        Spec.ForAny<int []>(fun xs -> 
-            let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
-            let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
-            x = y && !disposed = true).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``head``() =
-        Spec.ForAny<int []>(fun (xs : int []) ->
-            let x =
-                try xs |> Stream.ofArray |> Stream.head
-                with :? System.ArgumentException -> -1
-
-            let y =
-                try xs |> Seq.head
-                with :? System.ArgumentException -> -1
-
-            Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``tryHead``() =
-        Spec.ForAny<int []>(fun (xs : int []) ->
-            let x = xs |> Stream.ofArray |> Stream.tryHead
-            let y =
-                try Some (xs |> Seq.head)
-                with :? System.ArgumentException -> None
-
-            Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
-
-(*
-    [<Test>]
-    let ``isEmpty``() =
-        Spec.ForAny<int []>(fun (xs : int  []) ->
-            let x = xs |> Stream.ofArray |> Stream.isEmpty
-            let y = xs |> Array.isEmpty
-
-            Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
-*)
+                Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
 
 module PerfTests = 
   let AdhocPerformanceTest() = 


### PR DESCRIPTION
This fixes the problem mentioned in #28 where some of the state and cancellation-handler-connections were being allocated or wired up for iterators even if Bulk() was used to iterate.
