### PR TITLE
Hide representations while maintaining performance

### DIFF
--- a/src/Streams.Core/ParStreams.fs
+++ b/src/Streams.Core/ParStreams.fs
@@ -270,7 +270,7 @@ module ParStream =
                                 Func = (fun value -> 
                                         let stream' = f value
                                         let cts = CancellationTokenSource.CreateLinkedTokenSource(iterator.Cts.Token)
-                                        stream'.RunBulk { Complete = (fun () -> ()); Cont = (fun v -> iter v |> ignore); Cts = cts })
+                                        stream' |> Stream.Internals.iterCancel cts (fun v -> iter v |> ignore))
                                 Cts = iterator.Cts } 
                         member self.Result = collector.Result  }
                 stream.Apply collector }

--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -28,9 +28,10 @@ type Context<'T> = {
 }
 
 /// Represents a Stream of values.
-type Stream<'T> (* internal *) (run : Context<'T> -> Iterable) = 
-    member (* internal *) __.Run ctxt = run ctxt
-    member (* internal *) __.RunBulk ctxt = (run ctxt).Bulk()
+type Stream<'T> = 
+    { run : Context<'T> -> Iterable } 
+    member inline (* internal *) stream.Run ctxt = stream.run ctxt
+    member inline (* internal *) stream.RunBulk ctxt = (stream.run ctxt).Bulk()
     override self.ToString() = 
         seq {
             use enumerator = new StreamEnumerator<'T>(self) :> IEnumerator<'T>
@@ -64,7 +65,7 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
                 index <- index + 1
                 if index >= count then
                     count <- 0
-                    if iterable.Iterator.TryAdvance() then
+                    if iterator.TryAdvance() then
                         if count > 0 then 
                             index <- 0
                             true
@@ -86,6 +87,8 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
 /// Provides basic operations on Streams.
 [<RequireQualifiedAccessAttribute>]
 module Stream =
+
+    let inline internal Stream s = { run = s }
 
     /// <summary>The empty stream.</summary>
     /// <returns>An empty stream.</returns>
@@ -136,30 +139,30 @@ module Stream =
                         iterf source.[i]
                 complete ()
                 
-            let tryAdvance = 
+            let iterator() = 
                 let i = ref 0
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun () -> continueFlag := false) |> ignore
-                fun () -> 
-                    if not !continueFlag then
-                        false
-                    else if !i < source.Length then
-                        iterf source.[!i] 
+                { new Iterator with 
+                    member __.TryAdvance() = 
                         if not !continueFlag then
+                            false
+                        else if !i < source.Length then
+                            iterf source.[!i] 
+                            if not !continueFlag then
+                                complete ()
+                            incr i
+                            true
+                        else
+                            continueFlag := false
                             complete ()
-                        incr i
-                        true
-                    else
-                        continueFlag := false
-                        complete ()
-                        true
+                            true
+                    member __.Dispose() = 
+                        if not (cts = null) then cts.Dispose() }
             { new Iterable with 
                  member __.Bulk() = bulk()
-                 member __.Iterator = 
-                     { new Iterator with 
-                          member __.TryAdvance() = tryAdvance()
-                          member __.Dispose() = if not (cts = null) then cts.Dispose() } })
+                 member __.Iterator = iterator() })
 
     /// <summary>Wraps ResizeArray as a stream.</summary>
     /// <param name="source">The input array.</param>
@@ -180,30 +183,32 @@ module Stream =
                         iterf source.[i]
                 complete ()
 
-            let tryAdvance = 
+            let iterator() = 
                 let i = ref 0
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun () -> continueFlag := false) |> ignore
-                fun () -> 
-                    if not !continueFlag then
-                        false
-                    else if !i < source.Count then
-                        iterf source.[!i] 
+                { new Iterator with 
+                    member __.TryAdvance() = 
                         if not !continueFlag then
+                            false
+                        else if !i < source.Count then
+                            iterf source.[!i] 
+                            if not !continueFlag then
+                                complete ()
+                            incr i
+                            true
+                        else
+                            continueFlag := false
                             complete ()
-                        incr i
-                        true
-                    else
-                        continueFlag := false
-                        complete ()
-                        true
+                            true
+
+                    member __.Dispose() = 
+                        if not (cts = null) then cts.Dispose() }
+
             { new Iterable with 
                  member __.Bulk() = bulk()
-                 member __.Iterator = 
-                     { new Iterator with 
-                          member __.TryAdvance() = tryAdvance()
-                          member __.Dispose() = if not (cts = null) then cts.Dispose()  } })
+                 member __.Iterator = iterator() })
 
     /// <summary>Wraps seq as a stream.</summary>
     /// <param name="source">The input seq.</param>
@@ -229,31 +234,30 @@ module Stream =
                         iterf value
                     complete ()
 
-            let iterator = 
+            let iterator() = 
                 let enumerator = source.GetEnumerator()
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun () -> continueFlag := false) |> ignore
-                let tryAdvance () = 
-                    if not !continueFlag then
-                        false
-                    else if enumerator.MoveNext() then
-                        iterf enumerator.Current
-                        if not !continueFlag then
-                            complete ()
-                        true
-                    else
-                        continueFlag := false
-                        complete ()
-                        true
                 { new Iterator with 
-                     member __.TryAdvance() = tryAdvance()
+                     member __.TryAdvance() = 
+                        if not !continueFlag then
+                            false
+                        else if enumerator.MoveNext() then
+                            iterf enumerator.Current
+                            if not !continueFlag then
+                                complete ()
+                            true
+                        else
+                            continueFlag := false
+                            complete ()
+                            true
                      member __.Dispose() = 
                          if not (cts = null) then cts.Dispose() 
                          enumerator.Dispose() }
             { new Iterable with 
                  member __.Bulk() = bulk() 
-                 member __.Iterator = iterator  })
+                 member __.Iterator = iterator()  })
         
     /// <summary>Wraps an IEnumerable as a stream.</summary>
     /// <param name="source">The input seq.</param>
@@ -278,32 +282,30 @@ module Stream =
                         iterf (value :?> 'T)
                     complete ()
 
-            let iterator = 
+            let iterator() = 
                 let enumerator = source.GetEnumerator()
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun () -> continueFlag := false) |> ignore
-                let tryAdvance () = 
-                    if not !continueFlag || not <| enumerator.MoveNext()  then
+                { new Iterator with 
+                     member __.TryAdvance() = 
+                        if not !continueFlag || not <| enumerator.MoveNext()  then
+                            match enumerator with 
+                            | :? System.IDisposable as disposable -> disposable.Dispose()
+                            | _ -> ()
+                            false
+                        else
+                            iterf (enumerator.Current :?> 'T)
+                            true
+                     member __.Dispose() = 
                         match enumerator with 
                         | :? System.IDisposable as disposable -> disposable.Dispose()
                         | _ -> ()
-                        false
-                    else
-                        iterf (enumerator.Current :?> 'T)
-                        true
-                let dispose () = 
-                    match enumerator with 
-                    | :? System.IDisposable as disposable -> disposable.Dispose()
-                    | _ -> ()
-                    complete ()
-                    if not (cts = null) then cts.Dispose() 
-                { new Iterator with 
-                     member __.TryAdvance() = tryAdvance()
-                     member __.Dispose() = dispose() }
+                        complete ()
+                        if not (cts = null) then cts.Dispose()  }
             { new Iterable with 
                 member __.Bulk() = bulk()
-                member __.Iterator = iterator  })
+                member __.Iterator = iterator()  })
 
     /// <summary>Transforms each element of the input stream.</summary>
     /// <param name="f">A function to transform items from the input stream.</param>
@@ -373,18 +375,19 @@ module Stream =
                      source.Run { Complete = complete;
                                   Cont = (fun v -> (if cache.Count - !count = 0 then cache.Add(v)); incr count; iterf v);
                                   Cts = cts }
-                let iterator = iterable.Iterator 
                 let bulk' () = lock cache (fun () -> iterable.Bulk(); cached := Some (ofResizeArray cache))
-
-                //locking each next() seem's overkill
-                let tryAdvance' () = lock cache (fun () -> if iterator.TryAdvance() then true else cached := Some (ofResizeArray cache); false)
-
+                let iterator'() = 
+                    let iterator = iterable.Iterator 
+                    { new Iterator with 
+                        member __.TryAdvance() = 
+                            //locking each next() seem's overkill
+                            lock cache (fun () -> 
+                                if iterator.TryAdvance() then true 
+                                else cached := Some (ofResizeArray cache); false)
+                        member __.Dispose() = iterator.Dispose() } 
                 { new Iterable with 
                     member __.Bulk() = bulk'(); 
-                    member __.Iterator = 
-                        { new Iterator with 
-                            member __.TryAdvance() = tryAdvance'(); 
-                            member __.Dispose() = iterator.Dispose() } })
+                    member __.Iterator = iterator'() })
 
 
     /// <summary>Filters the elements of the input stream.</summary>
@@ -471,7 +474,7 @@ module Stream =
                 for stream in streams do
                     stream.RunBulk { Complete = (fun () -> ()); Cont = iterf; Cts = cts }
                 complete ()
-            let iterator =
+            let iterator() =
                 if Seq.isEmpty streams then 
                     { new Iterator with 
                         member __.TryAdvance() = false; 
@@ -488,28 +491,26 @@ module Stream =
                     let continueFlag = ref true
                     if not (cts = null) then
                         cts.Token.Register(fun _ -> continueFlag := false) |> ignore
-                    let tryAdvance () =
-                        if not !continueFlag then
-                            false
-                        else if enumerator.MoveNext() then
-                            iterf enumerator.Current 
-                            if not !continueFlag then
-                                complete ()
-                            true
-                        else 
-                            continueFlag := false
-                            complete ()
-                            true
-                    let dispose () =
-                        if not (cts = null) then cts.Dispose()
-                        enumerator.Dispose()
                     { new Iterator with 
-                        member __.TryAdvance() = tryAdvance() 
-                        member __.Dispose() = dispose() }
+                        member __.TryAdvance() = 
+                            if not !continueFlag then
+                                false
+                            else if enumerator.MoveNext() then
+                                iterf enumerator.Current 
+                                if not !continueFlag then
+                                    complete ()
+                                true
+                            else 
+                                continueFlag := false
+                                complete ()
+                                true
+                        member __.Dispose() = 
+                            if not (cts = null) then cts.Dispose()
+                            enumerator.Dispose() }
 
             { new Iterable with 
                 member __.Bulk() = bulk()
-                member __.Iterator = iterator })
+                member __.Iterator = iterator() })
 
 
 
@@ -534,35 +535,33 @@ module Stream =
                         next := false
                     ()
                 complete ()
-            let iterator = 
+            let iterator() = 
                 let continueFlag = ref true
                 if not (cts = null) then
                     cts.Token.Register(fun _ -> continueFlag := false) |> ignore
                 let firstEnumerator = new StreamEnumerator<'T>(first) :> IEnumerator<'T>
                 let secondEnumerator = new StreamEnumerator<'S>(second) :> IEnumerator<'S>
-                let tryAdvance () = 
-                    if not !continueFlag then
-                        false
-                    else if firstEnumerator.MoveNext() && secondEnumerator.MoveNext() then
-                        iterf (f firstEnumerator.Current secondEnumerator.Current)
-                        if not !continueFlag then
-                            complete ()
-                        true
-                    else
-                        continueFlag := false
-                        complete ()
-                        true
-                let dispose () = 
-                    if not (cts = null) then
-                        cts.Dispose()
-                    firstEnumerator.Dispose()
-                    secondEnumerator.Dispose()
                 { new Iterator with 
-                    member __.TryAdvance() = tryAdvance() 
-                    member __.Dispose() = dispose() }
+                    member __.TryAdvance() = 
+                        if not !continueFlag then
+                            false
+                        else if firstEnumerator.MoveNext() && secondEnumerator.MoveNext() then
+                            iterf (f firstEnumerator.Current secondEnumerator.Current)
+                            if not !continueFlag then
+                                complete ()
+                            true
+                        else
+                            continueFlag := false
+                            complete ()
+                            true
+                    member __.Dispose() = 
+                        if not (cts = null) then
+                            cts.Dispose()
+                        firstEnumerator.Dispose()
+                        secondEnumerator.Dispose() }
             { new Iterable with 
                 member __.Bulk() = bulk()
-                member __.Iterator = iterator })
+                member __.Iterator = iterator() })
 
 
     /// <summary>Applies a function to each element of the stream, threading an accumulator argument through the computation. If the input function is f and the elements are i0...iN, then this function computes f (... (f s i0)...) iN.</summary>

--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -99,7 +99,7 @@ module Stream =
                              Cts = cts })
 
         // Public permanent entrypoint to implement inlined versions of takeWhile etc.
-        // 'f' is called with one argument before iteration.
+        // 'f' is called with two arguments before iteration.
         let mapContCancel f stream =
             Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
                 let cts = if cts = null then new CancellationTokenSource() else cts 
@@ -109,7 +109,6 @@ module Stream =
                           Cts = cts })
 
         // Public permanent entrypoint to implement inlined versions of tryFind, tryPick
-        // 'f' is called with one argument before iteration.
         let iterCancel cts (f : ('T -> unit)) (stream : Stream<'T>) : unit = 
            stream.RunBulk
                 { Complete = (fun () -> ())

--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -30,6 +30,7 @@ type (* internal *) Context<'T> = {
 /// Represents a Stream of values.
 type Stream<'T> = 
     { Run : Context<'T> -> Iterable } 
+    member inline internal stream.RunBulk ctxt = (stream.Run ctxt).Bulk()
     override self.ToString() = 
         seq {
             use enumerator = new StreamEnumerator<'T>(self) :> IEnumerator<'T>
@@ -87,8 +88,6 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
 module Stream =
 
     let inline internal Stream f = { Run = f }
-    type Stream<'T> with 
-        member  inline (* internal *) stream.RunBulk ctxt = (stream.Run ctxt).Bulk()
 
     /// <summary>The empty stream.</summary>
     /// <returns>An empty stream.</returns>

--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -4,21 +4,21 @@ open System.Collections.Generic
 open System.Threading
 
 /// Provides on-demand iteration 
-type (* internal *) Iterator = 
+type internal Iterator = 
     /// Function for on-demand processing
     abstract TryAdvance : unit -> bool 
     /// Cleanup function
     abstract Dispose : unit -> unit 
 
 /// Provides functions for iteration
-type (* internal *) Iterable = 
+type internal Iterable = 
     /// Function for bulk processing
     abstract Bulk : unit -> unit 
     /// Iterator for on-demand processing
     abstract Iterator : Iterator
 
 /// Represents the current executing contex
-type (* internal *) Context<'T> = {
+type internal Context<'T> = {
     /// The composed continutation
     Cont : 'T -> unit
     /// The completed continuation
@@ -29,7 +29,7 @@ type (* internal *) Context<'T> = {
 
 /// Represents a Stream of values.
 type Stream<'T> = 
-    { Run : Context<'T> -> Iterable } 
+    internal { Run : Context<'T> -> Iterable } 
     member inline internal stream.RunBulk ctxt = (stream.Run ctxt).Bulk()
     override self.ToString() = 
         seq {
@@ -87,7 +87,34 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
 [<RequireQualifiedAccessAttribute>]
 module Stream =
 
-    let inline internal Stream f = { Run = f }
+    let inline  internal Stream f = { Run = f }
+
+    module Internals = 
+        // Public permanent entrypoint to implement inlined versions of map, filter, choose etc.
+        // 'f' is called with one argument before iteration.
+        let mapCont f stream =
+            Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
+                stream.Run { Complete = complete; 
+                             Cont = f iterf; 
+                             Cts = cts })
+
+        // Public permanent entrypoint to implement inlined versions of takeWhile etc.
+        // 'f' is called with one argument before iteration.
+        let mapContCancel f stream =
+            Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
+                let cts = if cts = null then new CancellationTokenSource() else cts 
+                stream.Run 
+                        { Complete = complete;
+                          Cont = f cts iterf;
+                          Cts = cts })
+
+        // Public permanent entrypoint to implement inlined versions of tryFind, tryPick
+        // 'f' is called with one argument before iteration.
+        let iterCancel cts (f : ('T -> unit)) (stream : Stream<'T>) : unit = 
+           stream.RunBulk
+                { Complete = (fun () -> ())
+                  Cont = f 
+                  Cts = cts } 
 
     /// <summary>The empty stream.</summary>
     /// <returns>An empty stream.</returns>
@@ -103,7 +130,7 @@ module Stream =
     /// <summary>Creates a singleton stream.</summary>
     /// <param name="source">The singleton stream element</param>
     /// <returns>A stream of just the given element</returns>
-    let inline singleton (source: 'T) : Stream<'T> =
+    let singleton (source: 'T) : Stream<'T> =
         Stream (fun { Complete = complete; Cont = iterf; Cts = cts }->
             let pulled = ref false
             { new Iterable with 
@@ -122,7 +149,7 @@ module Stream =
     /// <summary>Wraps array as a stream.</summary>
     /// <param name="source">The input array.</param>
     /// <returns>The result stream.</returns>
-    let inline ofArray (source : 'T []) : Stream<'T> =
+    let ofArray (source : 'T []) : Stream<'T> =
         Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
             let bulk () =
                 if not (cts = null) then
@@ -166,7 +193,7 @@ module Stream =
     /// <summary>Wraps ResizeArray as a stream.</summary>
     /// <param name="source">The input array.</param>
     /// <returns>The result stream.</returns>
-    let inline ofResizeArray (source : ResizeArray<'T>) : Stream<'T> =
+    let ofResizeArray (source : ResizeArray<'T>) : Stream<'T> =
         Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
             let bulk () =
                 if not (cts = null) then
@@ -212,7 +239,7 @@ module Stream =
     /// <summary>Wraps seq as a stream.</summary>
     /// <param name="source">The input seq.</param>
     /// <returns>The result stream.</returns>
-    let inline ofSeq (source : seq<'T>) : Stream<'T> =
+    let ofSeq (source : seq<'T>) : Stream<'T> =
         match source with
         | :? ('T[]) as array -> ofArray array
         | :? ResizeArray<'T> as list -> ofResizeArray list
@@ -261,7 +288,7 @@ module Stream =
     /// <summary>Wraps an IEnumerable as a stream.</summary>
     /// <param name="source">The input seq.</param>
     /// <returns>The result stream.</returns>
-    let inline cast<'T> (source : System.Collections.IEnumerable) : Stream<'T> =
+    let cast<'T> (source : System.Collections.IEnumerable) : Stream<'T> =
         Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
             let bulk () =
                 
@@ -306,32 +333,31 @@ module Stream =
                 member __.Bulk() = bulk()
                 member __.Iterator = iterator()  })
 
+    // Used to indicate that we don't want a tailcall on a continuation call
+    let inline internal notailcall() = Unchecked.defaultof<unit>
+    // Used to indicate that we don't want a closure to be curried
+    let inline internal nocurry() = Unchecked.defaultof<unit>
+
     /// <summary>Transforms each element of the input stream.</summary>
     /// <param name="f">A function to transform items from the input stream.</param>
     /// <param name="stream">The input stream.</param>
     /// <returns>The result stream.</returns>
     let inline map (f : 'T -> 'R) (stream : Stream<'T>) : Stream<'R> =
-        Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
-            stream.Run { Complete = complete; 
-                         Cont = (fun value -> iterf (f value)); 
-                         Cts = cts })
+        stream |> Internals.mapCont (fun iterf -> nocurry(); fun value -> iterf (f value); notailcall())
+
 
     /// <summary>Transforms each element of the input stream. The integer index passed to the function indicates the index (from 0) of element being transformed.</summary>
     /// <param name="f">A function to transform items and also supplies the current index.</param>
     /// <param name="stream">The input stream.</param>
     /// <returns>The result stream.</returns>
     let inline mapi (f : int -> 'T -> 'R) (stream : Stream<'T>) : Stream<'R> =
-        Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
-            let counter = ref -1
-            stream.Run { Complete = complete; 
-                         Cont = (fun value -> incr counter; iterf (f !counter value)); 
-                         Cts = cts })
+        stream |> Internals.mapCont (fun iterf -> let counter = ref -1 in (fun value -> incr counter; iterf (f !counter value); notailcall())) 
 
     /// <summary>Transforms each element of the input stream to a new stream and flattens its elements.</summary>
     /// <param name="f">A function to transform items from the input stream.</param>
     /// <param name="stream">The input stream.</param>
     /// <returns>The result stream.</returns>
-    let inline flatMap (f : 'T -> Stream<'R>) (stream : Stream<'T>) : Stream<'R> =
+    let flatMap (f : 'T -> Stream<'R>) (stream : Stream<'T>) : Stream<'R> =
         Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
             stream.Run
                     { Complete = complete;
@@ -355,7 +381,7 @@ module Stream =
     /// <summary>Creates a cached version of the input stream.</summary>
     /// <param name="source">The input stream.</param>
     /// <returns>The cached stream.</returns>
-    let inline cache (source: Stream<'T>): Stream<'T> =
+    let cache (source: Stream<'T>): Stream<'T> =
         let cache = new ResizeArray<'T>()
         //if !cached = None && cache.Count = 0 then the stream is not cached
         //if !cached = None && cache.Count > 0 then the stream is partially cached
@@ -392,28 +418,20 @@ module Stream =
     /// <param name="stream">The input stream.</param>
     /// <returns>The result stream.</returns>
     let inline filter (predicate : 'T -> bool) (stream : Stream<'T>) : Stream<'T> =
-        Stream (fun { Complete = complete; Cont = iterf; Cts = cts }  ->
-            stream.Run
-                    { Complete = complete;
-                      Cont = (fun value -> if predicate value then iterf value else ());
-                      Cts = cts })
+        stream |> Internals.mapCont (fun iterf -> nocurry(); fun value -> if predicate value then iterf value; notailcall())
 
     /// <summary>Applies the given function to each element of the stream and returns the stream comprised of the results for each element where the function returns Some with some value.</summary>
     /// <param name="chooser">A function to transform items of type 'T into options of type 'R.</param>
     /// <param name="stream">The input stream.</param>
     /// <returns>The result stream.</returns>
     let inline choose (chooser : 'T -> 'R option) (stream : Stream<'T>) : Stream<'R> =
-        Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
-            stream.Run
-                    { Complete = complete; 
-                      Cont = (fun value -> match chooser value with | Some value' -> iterf value' | None -> ());
-                      Cts = cts })
+        stream |> Internals.mapCont (fun iterf -> nocurry(); fun value -> match chooser value with | Some value' -> iterf value'; notailcall() | None -> ())
 
     /// <summary>Returns the elements of the stream up to a specified count.</summary>
     /// <param name="n">The number of items to take.</param>
     /// <param name="stream">The input stream.</param>
     /// <returns>The result stream.</returns>
-    let inline take (n : int) (stream : Stream<'T>) : Stream<'T> =
+    let take (n : int) (stream : Stream<'T>) : Stream<'T> =
         if n < 0 then
             raise <| new System.ArgumentException("The input must be non-negative.")
         Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
@@ -436,21 +454,14 @@ module Stream =
     /// <param name="stream">The input stream.</param>
     /// <returns>The result stream.</returns>
     let inline takeWhile pred (stream : Stream<'T>) : Stream<'T> = 
-        Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
-            let cts = if cts = null then new CancellationTokenSource() else cts 
-            stream.Run 
-                    { Complete = complete;
-                      Cont = 
-                        (fun value -> 
-                            if pred value then iterf value else cts.Cancel());
-                      Cts = cts })
+        stream |> Internals.mapContCancel (fun cts iterf -> nocurry(); fun value -> if pred value then iterf value; notailcall() else cts.Cancel())
         
 
     /// <summary>Returns a stream that skips N elements of the input stream and then yields the remaining elements of the stream.</summary>
     /// <param name="n">The number of items to skip.</param>
     /// <param name="stream">The input stream.</param>
     /// <returns>The result stream.</returns>
-    let inline skip (n : int) (stream : Stream<'T>) : Stream<'T> =
+    let skip (n : int) (stream : Stream<'T>) : Stream<'T> =
         Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
             let counter = ref 0
             stream.Run 
@@ -561,6 +572,15 @@ module Stream =
                 member __.Iterator = iterator() })
 
 
+    /// <summary>Applies the given function to each element of the stream.</summary>
+    /// <param name="f">A function to apply to each element of the stream.</param>
+    /// <param name="stream">The input stream.</param>    
+    let iter (f : 'T -> unit) (stream : Stream<'T>) : unit = 
+       stream.RunBulk
+            { Complete = (fun () -> ())
+              Cont = f
+              Cts = null } 
+
     /// <summary>Applies a function to each element of the stream, threading an accumulator argument through the computation. If the input function is f and the elements are i0...iN, then this function computes f (... (f s i0)...) iN.</summary>
     /// <param name="folder">A function that updates the state with each element from the stream.</param>
     /// <param name="state">The initial state.</param>
@@ -568,10 +588,7 @@ module Stream =
     /// <returns>The final result.</returns>
     let inline fold (folder : 'State -> 'T -> 'State) (state : 'State) (stream : Stream<'T>) : 'State =
         let accRef = ref state
-        stream.RunBulk
-            { Complete = (fun () -> ());
-              Cont = (fun value -> accRef := folder !accRef value);
-              Cts = null }
+        stream |> iter (fun value -> accRef := folder !accRef value)
         !accRef
 
     /// <summary>Like Stream.fold, but computes on-demand and returns the stream of intermediate and final results</summary>
@@ -580,13 +597,13 @@ module Stream =
     /// <param name="stream">The input stream.</param>
     /// <returns>The final stream.</returns>
     let inline scan (folder : 'State -> 'T -> 'State) (state : 'State) (stream : Stream<'T>) : Stream<'State> =
-        Stream (fun { Complete = complete; Cont = iterf; Cts = cts } ->
+        stream |> Internals.mapCont (fun iterf -> 
             let accRef = ref state
             iterf !accRef
-            stream.Run
-                 { Complete = complete;
-                   Cont = (fun value -> accRef := folder !accRef value; iterf !accRef);
-                   Cts = cts })
+            (fun value -> 
+                accRef := folder !accRef value
+                iterf !accRef
+                notailcall() ))
 
     /// <summary>Returns the sum of the elements.</summary>
     /// <param name="stream">The input stream.</param>
@@ -601,15 +618,6 @@ module Stream =
     /// <returns>The total number of elements.</returns>
     let inline length (stream : Stream<'T>) : int =
         fold (fun acc _  -> 1 + acc) 0 stream
-
-    /// <summary>Applies the given function to each element of the stream.</summary>
-    /// <param name="f">A function to apply to each element of the stream.</param>
-    /// <param name="stream">The input stream.</param>    
-    let inline iter (f : 'T -> unit) (stream : Stream<'T>) : unit = 
-       stream.RunBulk
-            { Complete = (fun () -> ())
-              Cont = (fun value -> f value)
-              Cts = null } 
 
     /// <summary>Creates an Seq from the given stream.</summary>
     /// <param name="stream">The input stream.</param>
@@ -641,10 +649,7 @@ module Stream =
     let inline sortBy<'T, 'Key when 'Key :> IComparable<'Key>> (projection : 'T -> 'Key) (stream : Stream<'T>) : Stream<'T> =
         let values = new List<'T>()
         let keys = new List<'Key>()
-        stream.RunBulk
-           { Complete = (fun () -> ());
-             Cont = (fun value -> keys.Add(projection value); values.Add(value));
-             Cts = null }
+        stream |> iter (fun value -> keys.Add(projection value); values.Add(value));
         let array = values.ToArray()
         Array.Sort(keys.ToArray(), array)
         array |> ofArray
@@ -696,21 +701,18 @@ module Stream =
     /// <param name="source">The input stream.</param>
     /// <returns>A stream of tuples where each tuple contains the unique key and a sequence of all the elements that match the key.</returns>    
     let inline foldBy (projection : 'T -> 'Key) (folder : 'State -> 'T -> 'State) 
-                        (init : unit -> 'State) (source : Stream<'T>) : Stream<'Key * 'State> =
+                      (init : unit -> 'State) (source : Stream<'T>) : Stream<'Key * 'State> =
 
         let dict = new Dictionary<'Key, 'State ref>()
 
-        let inline body (t : 'T) =
+        source |> iter (fun t -> 
             let key = projection t
             let mutable container = Unchecked.defaultof<'State ref>
             if not <| dict.TryGetValue(key, &container) then
                 container <- ref <| init ()
                 dict.Add(key, container)
+            container := folder container.Value t)
 
-            container := folder container.Value t
-            ()
-
-        source.RunBulk { Complete = (fun () -> ()); Cont = body; Cts = null }
         dict |> ofSeq |> map (fun keyValue -> (keyValue.Key, keyValue.Value.Value))
 
     /// <summary>Applies a key-generating function to each element of the input stream and yields a stream of unique keys and a sequence of all elements that have each key.</summary>
@@ -720,16 +722,13 @@ module Stream =
     let inline groupBy (projection : 'T -> 'Key) (source : Stream<'T>) : Stream<'Key * seq<'T>>  =
         let dict = new Dictionary<'Key, List<'T>>()
         
-        let inline body (t : 'T) = 
+        source |> iter (fun t -> 
             let mutable grouping = Unchecked.defaultof<List<'T>>
             let key = projection t
             if not <| dict.TryGetValue(key, &grouping) then
                 grouping <- new List<'T>()
                 dict.Add(key, grouping)
-            grouping.Add(t)
-            ()
-
-        source.RunBulk { Complete = (fun () -> ()); Cont = body; Cts = null } 
+            grouping.Add(t))
         dict |> ofSeq |> map (fun keyValue -> (keyValue.Key, keyValue.Value :> seq<'T>))
 
     /// <summary>Applies a key-generating function to each element of the input stream and yields a stream of unique keys and their frequency.</summary>
@@ -745,11 +744,8 @@ module Stream =
     /// <returns>The first element for which the predicate returns true, or None if every element evaluates to false.</returns>
     let inline tryFind (predicate : 'T -> bool) (stream : Stream<'T>) : 'T option = 
         let resultRef = ref Unchecked.defaultof<'T option>
-        let cts = new CancellationTokenSource()
-        stream.RunBulk 
-            { Complete = (fun () -> ());
-              Cont = (fun value -> if predicate value then resultRef := Some value; cts.Cancel(); else ());
-              Cts = cts } 
+        let cts = new CancellationTokenSource ()
+        stream |> Internals.iterCancel cts (fun value -> if predicate value then resultRef := Some value; cts.Cancel())
         !resultRef
 
     /// <summary>Returns the first element for which the given function returns true. Raises KeyNotFoundException if no such element exists.</summary>
@@ -768,11 +764,8 @@ module Stream =
     /// <returns>The first element for which the chooser returns Some, or None if every element evaluates to None.</returns>
     let inline tryPick (chooser : 'T -> 'R option) (stream : Stream<'T>) : 'R option = 
         let resultRef = ref Unchecked.defaultof<'R option>
-        let cts = new CancellationTokenSource()
-        stream.RunBulk
-            { Complete = (fun () -> ());
-              Cont = (fun value -> match chooser value with | Some value' -> resultRef := Some value'; cts.Cancel(); | None -> ())
-              Cts = cts } 
+        let cts = new CancellationTokenSource ()
+        stream |> Internals.iterCancel cts (fun value -> match chooser value with | Some value' -> resultRef := Some value'; cts.Cancel() | None -> ())
         !resultRef
 
     /// <summary>Applies the given function to successive elements, returning the first result where the function returns a Some value.
@@ -833,21 +826,18 @@ module Stream =
                       Cts = cts })
 
     /// <summary>
-    ///     Returs the first element of the stream.
+    ///     Returns the first element of the stream.
     /// </summary>
     /// <param name="stream">The input stream.</param>
     /// <returns>The first element of the stream, or None if the stream has no elements.</returns>
     let inline tryHead (stream : Stream<'T>) : 'T option =
         let stream' = take 1 stream
         let resultRef = ref Unchecked.defaultof<'T option>
-        stream'.RunBulk
-            { Complete = (fun () -> ());
-              Cont = (fun value -> resultRef := Some value);
-              Cts = null }
+        stream' |> iter (fun value -> resultRef := Some value)
         !resultRef
 
     /// <summary>
-    ///     Returs the first element of the stream.
+    ///     Returns the first element of the stream.
     /// </summary>
     /// <param name="stream">The input stream.</param>
     /// <returns>The first element of the stream.</returns>
@@ -859,7 +849,7 @@ module Stream =
 
 
     /// <summary>
-    ///     Returs true if the stream is empty and false otherwise.
+    ///     Returns true if the stream is empty and false otherwise.
     /// </summary>
     /// <param name="stream">The input stream.</param>
     /// <returns>true if the input stream is empty, false otherwise</returns>

--- a/src/Streams.Core/Streams.fs
+++ b/src/Streams.Core/Streams.fs
@@ -29,9 +29,8 @@ type Context<'T> = {
 
 /// Represents a Stream of values.
 type Stream<'T> = 
-    { run : Context<'T> -> Iterable } 
-    member inline (* internal *) stream.Run ctxt = stream.run ctxt
-    member inline (* internal *) stream.RunBulk ctxt = (stream.run ctxt).Bulk()
+    { Run : Context<'T> -> Iterable } 
+    member inline (* internal *) stream.RunBulk ctxt = (stream.Run ctxt).Bulk()
     override self.ToString() = 
         seq {
             use enumerator = new StreamEnumerator<'T>(self) :> IEnumerator<'T>
@@ -88,7 +87,7 @@ and private StreamEnumerator<'T> (stream : Stream<'T>) =
 [<RequireQualifiedAccessAttribute>]
 module Stream =
 
-    let inline internal Stream s = { run = s }
+    let inline internal Stream f = { Run = f }
 
     /// <summary>The empty stream.</summary>
     /// <returns>An empty stream.</returns>
@@ -316,7 +315,6 @@ module Stream =
             stream.Run { Complete = complete; 
                          Cont = (fun value -> iterf (f value)); 
                          Cts = cts })
-
 
     /// <summary>Transforms each element of the input stream. The integer index passed to the function indicates the index (from 0) of element being transformed.</summary>
     /// <param name="f">A function to transform items and also supplies the current index.</param>

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -420,6 +420,7 @@ module ``Streams tests``  =
 
                 Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
+(*
         [<Test>]
         let ``isEmpty``() =
             Spec.ForAny<int []>(fun (xs : int  []) ->
@@ -427,6 +428,7 @@ module ``Streams tests``  =
                 let y = xs |> Array.isEmpty
 
                 Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
+*)
 
 module PerfTests = 
   let AdhocPerformanceTest() = 
@@ -527,6 +529,13 @@ module PerfTests =
       // Real: 00:00:02.853, CPU: 00:00:02.859, GC gen0: 0, gen1: 0, gen2: 0
       // Real: 00:00:03.276, CPU: 00:00:03.234, GC gen0: 0, gen1: 0, gen2: 0
       // Real: 00:00:02.757, CPU: 00:00:02.718, GC gen0: 0, gen1: 0, gen2: 0
+      // New (without inlining but map partially inlined)
+      // Real: 00:00:08.328, CPU: 00:00:08.250, GC gen0: 0, gen1: 0, gen2: 0
+      // New (fully hidden represenations)
+      // Real: 00:00:02.980, CPU: 00:00:02.968, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.961, CPU: 00:00:02.953, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.009, CPU: 00:00:03.015, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.952, CPU: 00:00:02.921, GC gen0: 0, gen1: 0, gen2: 0
 
 
 

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -1,421 +1,537 @@
-﻿namespace Nessos.Streams.Tests
-    open System.Linq
-    open System.Collections.Generic
-    open FsCheck
-    open FsCheck.Fluent
-    open NUnit.Framework
-    open Nessos.Streams
+﻿#if INTERACTIVE
+#r @"../../bin/Streams.Core.dll"
+//#r @"../../packages/Streams.0.3.0/lib/net45/Streams.Core.dll"
+#r @"../../packages/NUnit.3.0.0-alpha/lib/net45/nunit.framework.dll"
+#r @"../../packages/FsCheck.1.0.1/lib/net45/FSCheck.dll"
+#time "on"
+#else
+namespace Nessos.Streams.Tests
+#endif
+open System.Linq
+open System.Collections.Generic
+open FsCheck
+open FsCheck.Fluent
+open NUnit.Framework
+open Nessos.Streams
 
-    [<TestFixture; Category("Streams.FSharp")>]
-    type ``Streams tests`` () =
+[<TestFixture; Category("Streams.FSharp")>]
+module ``Streams tests``  =
 
-        [<Test>]
-        member __.``ofArray`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map ((+)1) |> Stream.toArray
-                let y = xs |> Seq.map ((+)1) |> Seq.toArray
+    [<Test>]
+    let ``ofArray`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map ((+)1) |> Stream.toArray
+            let y = xs |> Seq.map ((+)1) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``ofResizeArray/toResizeArray`` () =
+        Spec.ForAny<ResizeArray<int>>(fun xs ->
+            let x = xs |> Stream.ofResizeArray |> Stream.map ((+)1) |> Stream.toResizeArray
+            let y = xs |> Seq.map ((+)1) |> Seq.toArray
+            (x.ToArray()) = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``ofSeq`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofSeq |> Stream.map ((+)1) |> Stream.toArray
+            let y = xs |> Seq.map ((+)1) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``toSeq`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
+            let y = xs |> Seq.collect (fun _ -> xs) |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``flatMap/toSeq`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.flatMap (fun x -> [|1..10|] |> Stream.ofArray) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
+            let y = xs |> Seq.collect (fun x -> [|1..10|]) |> Seq.map ((+)1) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``flatMap/find`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq) |> Stream.map ((+)1) |> Stream.find (fun _ -> true)
+            let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id) |> Seq.map ((+)1) |> Seq.find (fun _ -> true)
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``flatMap/take`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq |> Stream.take 10) |> Stream.map ((+)1) |> Stream.take 100 |> Stream.toArray
+            let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id |> Seq.take 10) |> Seq.map ((+)1) |> Seq.take 100 |> Seq.toArray 
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``map`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.toArray
+            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``mapi`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.mapi (fun i n -> i * n) |> Stream.toArray
+            let y = xs |> Seq.mapi (fun i n -> i * n) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``filter`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.toArray
+            let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``choose`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.choose (fun n -> if n % 2 = 0 then Some n else None) |> Stream.toArray
+            let y = xs |> Seq.choose (fun n -> if n % 2 = 0 then Some n else None) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``collect`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.collect (fun n -> [|1..n|] |> Stream.ofArray) |> Stream.toArray
+            let y = xs |> Seq.collect (fun n -> [|1..n|]) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``fold`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.fold (+) 0 
+            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.fold (+) 0 
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``scan`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.scan (+) 0 |> Stream.toArray 
+            let y = xs |> Seq.scan (+) 0 |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()            
+
+    [<Test>]
+    let ``sum`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.sum
+            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.sum
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``length`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.length
+            let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.length
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``sortBy`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.map ((+) 1) |> Stream.sortBy id |> Stream.toArray
+            let y = xs |> Seq.map ((+) 1) |> Seq.sortBy id |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``minBy`` () =
+        Spec.ForAny<int[]>(fun xs -> 
+            if Array.isEmpty xs then
+                try let _ = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1) in false
+                with :? System.ArgumentException -> true
+            else
+                let x = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1)
+                let y = xs |> Seq.minBy (fun i -> i + 1)
                 x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``ofResizeArray/toResizeArray`` () =
-            Spec.ForAny<ResizeArray<int>>(fun xs ->
-                let x = xs |> Stream.ofResizeArray |> Stream.map ((+)1) |> Stream.toResizeArray
-                let y = xs |> Seq.map ((+)1) |> Seq.toArray
-                (x.ToArray()) = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``ofSeq`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofSeq |> Stream.map ((+)1) |> Stream.toArray
-                let y = xs |> Seq.map ((+)1) |> Seq.toArray
+    [<Test>]
+    let ``maxBy`` () =
+        Spec.ForAny<int[]>(fun xs -> 
+            if Array.isEmpty xs then 
+                try let _ = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1) in false
+                with :? System.ArgumentException -> true
+            else
+                let x = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1)
+                let y = xs |> Seq.maxBy (fun i -> i + 1)
                 x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``toSeq`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
-                let y = xs |> Seq.collect (fun _ -> xs) |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``countBy`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.countBy (fun i -> i % 5) |> Stream.toArray
+            let y = xs |> Seq.countBy (fun i -> i % 5) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``flatMap/toSeq`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.flatMap (fun x -> [|1..10|] |> Stream.ofArray) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
-                let y = xs |> Seq.collect (fun x -> [|1..10|]) |> Seq.map ((+)1) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``foldBy`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs 
+                    |> Stream.ofArray 
+                    |> Stream.foldBy id (fun ts t -> t :: ts) (fun () -> []) // groupBy implementation
+                    |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
+                    |> Stream.toArray
+            let y = xs  
+                    |> Seq.groupBy id 
+                    |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
+                    |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``flatMap/find`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq) |> Stream.map ((+)1) |> Stream.find (fun _ -> true)
-                let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id) |> Seq.map ((+)1) |> Seq.find (fun _ -> true)
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``groupBy`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs 
+                    |> Stream.ofArray 
+                    |> Stream.groupBy id  
+                    |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
+                    |> Stream.toArray
+            let y = xs  
+                    |> Seq.groupBy id 
+                    |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
+                    |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``flatMap/take`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq |> Stream.take 10) |> Stream.map ((+)1) |> Stream.take 100 |> Stream.toArray
-                let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id |> Seq.take 10) |> Seq.map ((+)1) |> Seq.take 100 |> Seq.toArray 
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``take`` () =
+        Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
+            let n = System.Math.Abs(n) 
+            let x = xs |> Stream.ofArray |> Stream.take n |> Stream.length
+            let y = xs.Take(n).Count()
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``map`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.toArray
-                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``mapi`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.mapi (fun i n -> i * n) |> Stream.toArray
-                let y = xs |> Seq.mapi (fun i n -> i * n) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``filter`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.toArray
-                let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``choose`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.choose (fun n -> if n % 2 = 0 then Some n else None) |> Stream.toArray
-                let y = xs |> Seq.choose (fun n -> if n % 2 = 0 then Some n else None) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``collect`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.collect (fun n -> [|1..n|] |> Stream.ofArray) |> Stream.toArray
-                let y = xs |> Seq.collect (fun n -> [|1..n|]) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``fold`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.fold (+) 0 
-                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.fold (+) 0 
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``scan`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.scan (+) 0 |> Stream.toArray 
-                let y = xs |> Seq.scan (+) 0 |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()            
-
-        [<Test>]
-        member __.``sum`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.sum
-                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.sum
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``length`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.length
-                let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.length
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``sortBy`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.map ((+) 1) |> Stream.sortBy id |> Stream.toArray
-                let y = xs |> Seq.map ((+) 1) |> Seq.sortBy id |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``minBy`` () =
-            Spec.ForAny<int[]>(fun xs -> 
-                if Array.isEmpty xs then
-                    try let _ = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1) in false
-                    with :? System.ArgumentException -> true
-                else
-                    let x = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1)
-                    let y = xs |> Seq.minBy (fun i -> i + 1)
-                    x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``maxBy`` () =
-            Spec.ForAny<int[]>(fun xs -> 
-                if Array.isEmpty xs then 
-                    try let _ = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1) in false
-                    with :? System.ArgumentException -> true
-                else
-                    let x = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1)
-                    let y = xs |> Seq.maxBy (fun i -> i + 1)
-                    x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``countBy`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.countBy (fun i -> i % 5) |> Stream.toArray
-                let y = xs |> Seq.countBy (fun i -> i % 5) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``foldBy`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs 
-                        |> Stream.ofArray 
-                        |> Stream.foldBy id (fun ts t -> t :: ts) (fun () -> []) // groupBy implementation
-                        |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
-                        |> Stream.toArray
-                let y = xs  
-                        |> Seq.groupBy id 
-                        |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
-                        |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``groupBy`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs 
-                        |> Stream.ofArray 
-                        |> Stream.groupBy id  
-                        |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
-                        |> Stream.toArray
-                let y = xs  
-                        |> Seq.groupBy id 
-                        |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
-                        |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``take`` () =
-            Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
-                let n = System.Math.Abs(n) 
-                let x = xs |> Stream.ofArray |> Stream.take n |> Stream.length
-                let y = xs.Take(n).Count()
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``take/boundary check`` () =
-            Spec.ForAny<int>(fun (n : int) ->
-                let refs = [| 1; 2; 3; 4 |]
-                let n = System.Math.Abs(n) 
-                let x = [|1..n|]
-                        |> Stream.ofArray
-                        |> Stream.map (fun i -> refs.[i])
-                        |> Stream.take 3
-                        |> Stream.toArray
-                let y = ([|1..n|] |> Seq.map (fun i -> refs.[i])).Take(3).ToArray()
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``take/boundary check`` () =
+        Spec.ForAny<int>(fun (n : int) ->
+            let refs = [| 1; 2; 3; 4 |]
+            let n = System.Math.Abs(n) 
+            let x = [|1..n|]
+                    |> Stream.ofArray
+                    |> Stream.map (fun i -> refs.[i])
+                    |> Stream.take 3
+                    |> Stream.toArray
+            let y = ([|1..n|] |> Seq.map (fun i -> refs.[i])).Take(3).ToArray()
+            x = y).QuickCheckThrowOnFailure()
         
 
 
                 
-        [<Test>]
-        member __.``takeWhile`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let pred = (fun value -> value % 2 = 0)
-                let x = xs |> Stream.ofArray |> Stream.takeWhile pred |> Stream.length
-                let y = xs.TakeWhile(pred).Count()
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``takeWhile`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let pred = (fun value -> value % 2 = 0)
+            let x = xs |> Stream.ofArray |> Stream.takeWhile pred |> Stream.length
+            let y = xs.TakeWhile(pred).Count()
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``collect/take`` () =
-            Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
-                let n = System.Math.Abs(n) 
-                let x = xs |> Stream.ofArray |> Stream.collect(fun x -> xs |> Stream.ofArray |> Stream.take n) |> Stream.length
-                let y = xs.SelectMany(fun x -> xs.Take(n)).Count()
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``collect/take`` () =
+        Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
+            let n = System.Math.Abs(n) 
+            let x = xs |> Stream.ofArray |> Stream.collect(fun x -> xs |> Stream.ofArray |> Stream.take n) |> Stream.length
+            let y = xs.SelectMany(fun x -> xs.Take(n)).Count()
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``skip`` () =
-            Spec.ForAny<int[] * int>(fun (xs, (n : int)) -> 
-                let x = xs |> Stream.ofArray |> Stream.skip n |> Stream.length
-                let y = xs.Skip(n).Count()
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``skip`` () =
+        Spec.ForAny<int[] * int>(fun (xs, (n : int)) -> 
+            let x = xs |> Stream.ofArray |> Stream.skip n |> Stream.length
+            let y = xs.Skip(n).Count()
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``tryFind`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.tryFind (fun n -> n % 2 = 0) 
-                let y = xs |> Seq.tryFind (fun n -> n % 2 = 0) 
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``tryFind`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.tryFind (fun n -> n % 2 = 0) 
+            let y = xs |> Seq.tryFind (fun n -> n % 2 = 0) 
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``find`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = try xs |> Stream.ofArray |> Stream.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
-                let y = try xs |> Seq.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``find`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = try xs |> Stream.ofArray |> Stream.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
+            let y = try xs |> Seq.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``tryPick`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
-                let y = xs |> Seq.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``tryPick`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
+            let y = xs |> Seq.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``pick`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = try xs |> Stream.ofArray |> Stream.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
-                let y = try xs |> Seq.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``pick`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = try xs |> Stream.ofArray |> Stream.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
+            let y = try xs |> Seq.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
+            x = y).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``exists`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.exists (fun n -> n % 2 = 0) 
-                let y = xs |> Seq.exists (fun n -> n % 2 = 0) 
-                x = y).QuickCheckThrowOnFailure()
-
-
-        [<Test>]
-        member __.``forall`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.forall (fun n -> n % 2 = 0) 
-                let y = xs |> Seq.forall (fun n -> n % 2 = 0) 
-                x = y).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``exists`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.exists (fun n -> n % 2 = 0) 
+            let y = xs |> Seq.exists (fun n -> n % 2 = 0) 
+            x = y).QuickCheckThrowOnFailure()
 
 
-
-        [<Test>]
-        member __.``zipWith`` () =
-            Spec.ForAny<(int[] * int[])>(fun (xs, ys) ->
-                let x = xs |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0) |> Stream.zipWith (fun x y -> x + y) (ys |> Stream.ofArray) |> Stream.toArray
-                let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.zip ys |> Seq.map (fun (x, y) -> x + y) |> Seq.toArray
-                x = y).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``empty`` () =
-            //for bulk
-            Assert.AreEqual(0, Stream.empty<int> |> Stream.length)
-            //for next
-            Assert.AreEqual(0, Stream.empty<int> |> Stream.toSeq |> Seq.length)
-
-        [<Test>]
-        member __.``concat`` () =
-            Spec.ForAny<int[][]>(fun xs ->
-                let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toArray
-                let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
-                Assert.AreEqual(x, y)
-                let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toSeq |> Seq.toArray
-                let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
-                Assert.AreEqual(x, y)
-                ).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``forall`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.forall (fun n -> n % 2 = 0) 
+            let y = xs |> Seq.forall (fun n -> n % 2 = 0) 
+            x = y).QuickCheckThrowOnFailure()
 
 
-        [<Test>]
-        member __.``cast`` () =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |>  Stream.cast |> Stream.toArray
-                let y = xs |> Seq.cast |> Seq.toArray
-                Assert.AreEqual(x, y)
-                let x = xs |>  Stream.cast |> Stream.toSeq |> Seq.length
-                let y = xs |> Seq.cast |> Seq.length
-                Assert.AreEqual(x, y)
-                ).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``cache``() =
-            Spec.ForAny<int[]>(fun xs ->
-                let x = xs |> Stream.ofArray |> Stream.cache |> Stream.toArray
-                let y = xs |> Seq.cache |> Seq.toArray
-                Assert.AreEqual(x, y)
-                let cached = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-                let cachedSeq = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
-                let x' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
-                let x'' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
-                Assert.AreEqual(x', x'')
-                let y' = cachedSeq |> Seq.map (fun x -> x + 1) |> Seq.toArray
-                Assert.AreEqual(x', y')
+    [<Test>]
+    let ``zipWith`` () =
+        Spec.ForAny<(int[] * int[])>(fun (xs, ys) ->
+            let x = xs |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0) |> Stream.zipWith (fun x y -> x + y) (ys |> Stream.ofArray) |> Stream.toArray
+            let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.zip ys |> Seq.map (fun (x, y) -> x + y) |> Seq.toArray
+            x = y).QuickCheckThrowOnFailure()
 
-                let cached' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-                let cachedSeq' = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+    [<Test>]
+    let ``empty`` () =
+        //for bulk
+        Assert.AreEqual(0, Stream.empty<int> |> Stream.length)
+        //for next
+        Assert.AreEqual(0, Stream.empty<int> |> Stream.toSeq |> Seq.length)
 
-                let count = ref 0
-                try cached' |> Stream.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
-                try cachedSeq' |> Seq.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
-                let x''' = cached' |> Stream.map (fun x -> x + 1) |> Stream.toArray
-                let y''' = cachedSeq' |> Seq.map (fun x -> x + 1) |> Seq.toArray
-                Assert.AreEqual(x''', y''')
-                Assert.AreEqual(x''', x'')
-
-                let cached'' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-                let x4 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toSeq |> Seq.toArray
-                let x5 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toArray
-                Assert.AreEqual(x4, x5)
-                ).QuickCheckThrowOnFailure()
-
-        [<Test>]
-        member __.``groupUntil``() =
-            Spec.ForAny<int []>(fun xs ->
-                // push-based tests
-                let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toArray |> Array.concat
-                Assert.AreEqual(xs, ys)
-                let failedPredicates = ref 0
-                let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toArray |> Seq.concat |> Seq.length
-                Assert.AreEqual(xs.Length, ys + !failedPredicates)
-                // pull-based tests
-                let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toSeq |> Array.concat
-                Assert.AreEqual(xs, ys)
-                let failedPredicates = ref 0
-                let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toSeq |> Seq.concat |> Seq.length
-                Assert.AreEqual(xs.Length, ys + !failedPredicates)
+    [<Test>]
+    let ``concat`` () =
+        Spec.ForAny<int[][]>(fun xs ->
+            let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toArray
+            let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
+            Assert.AreEqual(x, y)
+            let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toSeq |> Seq.toArray
+            let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
+            Assert.AreEqual(x, y)
             ).QuickCheckThrowOnFailure()
 
 
-        [<Test>]
-        member __.``seq/dispose``() =
-            let disposed = ref false
-            let testEnumerator (array : int []) = 
-                disposed := false
-                let index = ref -1
-                {   new IEnumerator<int> with
-                        member self.Current = array.[!index]
-                    interface System.Collections.IEnumerator with  
-                        member self.Current = box array.[!index]
-                        member self.MoveNext() = 
-                            incr index
-                            if !index >= array.Length then false else true
-                        member self.Reset() = index := -1 
-                    interface System.IDisposable with  
-                        member self.Dispose() = disposed := true }
-            let testEnumerable (array : int []) = 
-                {   new IEnumerable<int> with
-                        member self.GetEnumerator() = testEnumerator array
-                    interface System.Collections.IEnumerable with
-                        member self.GetEnumerator() = testEnumerator array :> _ }
-            Spec.ForAny<int []>(fun xs -> 
-                let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
-                let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
-                x = y && !disposed = true).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``cast`` () =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |>  Stream.cast |> Stream.toArray
+            let y = xs |> Seq.cast |> Seq.toArray
+            Assert.AreEqual(x, y)
+            let x = xs |>  Stream.cast |> Stream.toSeq |> Seq.length
+            let y = xs |> Seq.cast |> Seq.length
+            Assert.AreEqual(x, y)
+            ).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``head``() =
-            Spec.ForAny<int []>(fun (xs : int []) ->
-                let x =
-                    try xs |> Stream.ofArray |> Stream.head
-                    with :? System.ArgumentException -> -1
+    [<Test>]
+    let ``cache``() =
+        Spec.ForAny<int[]>(fun xs ->
+            let x = xs |> Stream.ofArray |> Stream.cache |> Stream.toArray
+            let y = xs |> Seq.cache |> Seq.toArray
+            Assert.AreEqual(x, y)
+            let cached = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+            let cachedSeq = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+            let x' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
+            let x'' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
+            Assert.AreEqual(x', x'')
+            let y' = cachedSeq |> Seq.map (fun x -> x + 1) |> Seq.toArray
+            Assert.AreEqual(x', y')
 
-                let y =
-                    try xs |> Seq.head
-                    with :? System.ArgumentException -> -1
+            let cached' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+            let cachedSeq' = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
 
-                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+            let count = ref 0
+            try cached' |> Stream.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
+            try cachedSeq' |> Seq.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
+            let x''' = cached' |> Stream.map (fun x -> x + 1) |> Stream.toArray
+            let y''' = cachedSeq' |> Seq.map (fun x -> x + 1) |> Seq.toArray
+            Assert.AreEqual(x''', y''')
+            Assert.AreEqual(x''', x'')
 
-        [<Test>]
-        member __.``tryHead``() =
-            Spec.ForAny<int []>(fun (xs : int []) ->
-                let x = xs |> Stream.ofArray |> Stream.tryHead
-                let y =
-                    try Some (xs |> Seq.head)
-                    with :? System.ArgumentException -> None
+            let cached'' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+            let x4 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toSeq |> Seq.toArray
+            let x5 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toArray
+            Assert.AreEqual(x4, x5)
+            ).QuickCheckThrowOnFailure()
 
-                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``groupUntil``() =
+        Spec.ForAny<int []>(fun xs ->
+            // push-based tests
+            let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toArray |> Array.concat
+            Assert.AreEqual(xs, ys)
+            let failedPredicates = ref 0
+            let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toArray |> Seq.concat |> Seq.length
+            Assert.AreEqual(xs.Length, ys + !failedPredicates)
+            // pull-based tests
+            let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toSeq |> Array.concat
+            Assert.AreEqual(xs, ys)
+            let failedPredicates = ref 0
+            let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toSeq |> Seq.concat |> Seq.length
+            Assert.AreEqual(xs.Length, ys + !failedPredicates)
+        ).QuickCheckThrowOnFailure()
 
-        [<Test>]
-        member __.``isEmpty``() =
-            Spec.ForAny<int []>(fun (xs : int  []) ->
-                let x = xs |> Stream.ofArray |> Stream.isEmpty
-                let y = xs |> Array.isEmpty
 
-                Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
+    [<Test>]
+    let ``seq/dispose``() =
+        let disposed = ref false
+        let testEnumerator (array : int []) = 
+            disposed := false
+            let index = ref -1
+            {   new IEnumerator<int> with
+                    member self.Current = array.[!index]
+                interface System.Collections.IEnumerator with  
+                    member self.Current = box array.[!index]
+                    member self.MoveNext() = 
+                        incr index
+                        if !index >= array.Length then false else true
+                    member self.Reset() = index := -1 
+                interface System.IDisposable with  
+                    member self.Dispose() = disposed := true }
+        let testEnumerable (array : int []) = 
+            {   new IEnumerable<int> with
+                    member self.GetEnumerator() = testEnumerator array
+                interface System.Collections.IEnumerable with
+                    member self.GetEnumerator() = testEnumerator array :> _ }
+        Spec.ForAny<int []>(fun xs -> 
+            let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
+            let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
+            x = y && !disposed = true).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``head``() =
+        Spec.ForAny<int []>(fun (xs : int []) ->
+            let x =
+                try xs |> Stream.ofArray |> Stream.head
+                with :? System.ArgumentException -> -1
+
+            let y =
+                try xs |> Seq.head
+                with :? System.ArgumentException -> -1
+
+            Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+
+    [<Test>]
+    let ``tryHead``() =
+        Spec.ForAny<int []>(fun (xs : int []) ->
+            let x = xs |> Stream.ofArray |> Stream.tryHead
+            let y =
+                try Some (xs |> Seq.head)
+                with :? System.ArgumentException -> None
+
+            Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
+
+(*
+    [<Test>]
+    let ``isEmpty``() =
+        Spec.ForAny<int []>(fun (xs : int  []) ->
+            let x = xs |> Stream.ofArray |> Stream.isEmpty
+            let y = xs |> Array.isEmpty
+
+            Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
+*)
+
+module PerfTests = 
+  let AdhocPerformanceTest() = 
+
+    let xs = Array.init 1000000 id
+
+    let runSeq() =
+        xs
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.map ((+) 1)
+        |> Seq.map ((-) 1)
+        |> Seq.filter (fun x -> x % 2 = 0)
+        |> Seq.length
+
+    let runList() =
+        xs
+        |> List.ofArray
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.map ((+) 1)
+        |> List.map ((-) 1)
+        |> List.filter (fun x -> x % 2 = 0)
+        |> List.length
+
+ 
+    let runArray() =
+        xs
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.map ((+) 1)
+        |> Array.map ((-) 1)
+        |> Array.filter (fun x -> x % 2 = 0)
+        |> Array.length
+
+    let runStream() =
+     for i in 0 .. 100 do
+        xs 
+        |> Stream.ofArray
+        |> Stream.take 1000000
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.map ((+) 1)
+        |> Stream.map ((-) 1)
+        |> Stream.filter (fun x -> x % 2 = 0)
+        |> Stream.length
+        |> ignore
+
+    runSeq() |> ignore
+    runList() |> ignore
+    runStream() |> ignore
+      //0.3.0: 
+      // Real: 00:00:03.696, CPU: 00:00:03.671, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.519, CPU: 00:00:03.515, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:04.427, CPU: 00:00:04.406, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.735, CPU: 00:00:02.718, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.358, CPU: 00:00:03.359, GC gen0: 0, gen1: 0, gen2: 0
+      // New (with inlining)
+      // Real: 00:00:03.893, CPU: 00:00:03.906, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.672, CPU: 00:00:02.625, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.298, CPU: 00:00:03.296, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.859, CPU: 00:00:02.859, GC gen0: 1, gen1: 0, gen2: 0
+      // Real: 00:00:03.102, CPU: 00:00:03.093, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:04.127, CPU: 00:00:04.093, GC gen0: 0, gen1: 0, gen2: 0
+      // New (without inlining)
+      // Real: 00:00:17.211, CPU: 00:00:16.937, GC gen0: 1, gen1: 0, gen2: 0
+      // Real: 00:00:17.750, CPU: 00:00:17.687, GC gen0: 0, gen1: 0, gen2: 0
+      // New (with inlining and Stream as record)
+      // Real: 00:00:02.411, CPU: 00:00:02.390, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.487, CPU: 00:00:02.468, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.428, CPU: 00:00:02.437, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.465, CPU: 00:00:02.468, GC gen0: 1, gen1: 0, gen2: 0
+      // Real: 00:00:02.495, CPU: 00:00:02.484, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.853, CPU: 00:00:02.859, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:03.276, CPU: 00:00:03.234, GC gen0: 0, gen1: 0, gen2: 0
+      // Real: 00:00:02.757, CPU: 00:00:02.718, GC gen0: 0, gen1: 0, gen2: 0
+
+
+
+    runArray() |> ignore
+ 
+

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -17,418 +17,416 @@ open Nessos.Streams
 [<TestFixture; Category("Streams.FSharp")>]
 module ``Streams tests``  =
 
-    [<Test>]
-    let ``ofArray`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map ((+)1) |> Stream.toArray
-            let y = xs |> Seq.map ((+)1) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``ofResizeArray/toResizeArray`` () =
-        Spec.ForAny<ResizeArray<int>>(fun xs ->
-            let x = xs |> Stream.ofResizeArray |> Stream.map ((+)1) |> Stream.toResizeArray
-            let y = xs |> Seq.map ((+)1) |> Seq.toArray
-            (x.ToArray()) = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``ofSeq`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofSeq |> Stream.map ((+)1) |> Stream.toArray
-            let y = xs |> Seq.map ((+)1) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``toSeq`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
-            let y = xs |> Seq.collect (fun _ -> xs) |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``flatMap/toSeq`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.flatMap (fun x -> [|1..10|] |> Stream.ofArray) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
-            let y = xs |> Seq.collect (fun x -> [|1..10|]) |> Seq.map ((+)1) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``flatMap/find`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq) |> Stream.map ((+)1) |> Stream.find (fun _ -> true)
-            let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id) |> Seq.map ((+)1) |> Seq.find (fun _ -> true)
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``flatMap/take`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq |> Stream.take 10) |> Stream.map ((+)1) |> Stream.take 100 |> Stream.toArray
-            let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id |> Seq.take 10) |> Seq.map ((+)1) |> Seq.take 100 |> Seq.toArray 
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``map`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.toArray
-            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``mapi`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.mapi (fun i n -> i * n) |> Stream.toArray
-            let y = xs |> Seq.mapi (fun i n -> i * n) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``filter`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.toArray
-            let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``choose`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.choose (fun n -> if n % 2 = 0 then Some n else None) |> Stream.toArray
-            let y = xs |> Seq.choose (fun n -> if n % 2 = 0 then Some n else None) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``collect`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.collect (fun n -> [|1..n|] |> Stream.ofArray) |> Stream.toArray
-            let y = xs |> Seq.collect (fun n -> [|1..n|]) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``fold`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.fold (+) 0 
-            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.fold (+) 0 
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``scan`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.scan (+) 0 |> Stream.toArray 
-            let y = xs |> Seq.scan (+) 0 |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()            
-
-    [<Test>]
-    let ``sum`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.sum
-            let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.sum
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``length`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.length
-            let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.length
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``sortBy`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.map ((+) 1) |> Stream.sortBy id |> Stream.toArray
-            let y = xs |> Seq.map ((+) 1) |> Seq.sortBy id |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``minBy`` () =
-        Spec.ForAny<int[]>(fun xs -> 
-            if Array.isEmpty xs then
-                try let _ = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1) in false
-                with :? System.ArgumentException -> true
-            else
-                let x = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1)
-                let y = xs |> Seq.minBy (fun i -> i + 1)
+        [<Test>]
+        let ``ofArray`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map ((+)1) |> Stream.toArray
+                let y = xs |> Seq.map ((+)1) |> Seq.toArray
                 x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``maxBy`` () =
-        Spec.ForAny<int[]>(fun xs -> 
-            if Array.isEmpty xs then 
-                try let _ = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1) in false
-                with :? System.ArgumentException -> true
-            else
-                let x = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1)
-                let y = xs |> Seq.maxBy (fun i -> i + 1)
+        [<Test>]
+        let ``ofResizeArray/toResizeArray`` () =
+            Spec.ForAny<ResizeArray<int>>(fun xs ->
+                let x = xs |> Stream.ofResizeArray |> Stream.map ((+)1) |> Stream.toResizeArray
+                let y = xs |> Seq.map ((+)1) |> Seq.toArray
+                (x.ToArray()) = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``ofSeq`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofSeq |> Stream.map ((+)1) |> Stream.toArray
+                let y = xs |> Seq.map ((+)1) |> Seq.toArray
                 x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``countBy`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.countBy (fun i -> i % 5) |> Stream.toArray
-            let y = xs |> Seq.countBy (fun i -> i % 5) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``toSeq`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
+                let y = xs |> Seq.collect (fun _ -> xs) |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``foldBy`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs 
-                    |> Stream.ofArray 
-                    |> Stream.foldBy id (fun ts t -> t :: ts) (fun () -> []) // groupBy implementation
-                    |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
-                    |> Stream.toArray
-            let y = xs  
-                    |> Seq.groupBy id 
-                    |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
-                    |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``flatMap/toSeq`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.flatMap (fun x -> [|1..10|] |> Stream.ofArray) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray
+                let y = xs |> Seq.collect (fun x -> [|1..10|]) |> Seq.map ((+)1) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``groupBy`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs 
-                    |> Stream.ofArray 
-                    |> Stream.groupBy id  
-                    |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
-                    |> Stream.toArray
-            let y = xs  
-                    |> Seq.groupBy id 
-                    |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
-                    |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``flatMap/find`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq) |> Stream.map ((+)1) |> Stream.find (fun _ -> true)
+                let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id) |> Seq.map ((+)1) |> Seq.find (fun _ -> true)
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``take`` () =
-        Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
-            let n = System.Math.Abs(n) 
-            let x = xs |> Stream.ofArray |> Stream.take n |> Stream.length
-            let y = xs.Take(n).Count()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``flatMap/take`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = Seq.initInfinite id |> Stream.ofSeq |> Stream.flatMap (fun x -> Seq.initInfinite id |> Stream.ofSeq |> Stream.take 10) |> Stream.map ((+)1) |> Stream.take 100 |> Stream.toArray
+                let y = Seq.initInfinite id |> Seq.collect (fun x -> Seq.initInfinite id |> Seq.take 10) |> Seq.map ((+)1) |> Seq.take 100 |> Seq.toArray 
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``take/boundary check`` () =
-        Spec.ForAny<int>(fun (n : int) ->
-            let refs = [| 1; 2; 3; 4 |]
-            let n = System.Math.Abs(n) 
-            let x = [|1..n|]
-                    |> Stream.ofArray
-                    |> Stream.map (fun i -> refs.[i])
-                    |> Stream.take 3
-                    |> Stream.toArray
-            let y = ([|1..n|] |> Seq.map (fun i -> refs.[i])).Take(3).ToArray()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``map`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.toArray
+                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``mapi`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.mapi (fun i n -> i * n) |> Stream.toArray
+                let y = xs |> Seq.mapi (fun i n -> i * n) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``filter`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.toArray
+                let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``choose`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.choose (fun n -> if n % 2 = 0 then Some n else None) |> Stream.toArray
+                let y = xs |> Seq.choose (fun n -> if n % 2 = 0 then Some n else None) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``collect`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.collect (fun n -> [|1..n|] |> Stream.ofArray) |> Stream.toArray
+                let y = xs |> Seq.collect (fun n -> [|1..n|]) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``fold`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.fold (+) 0 
+                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.fold (+) 0 
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``scan`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.scan (+) 0 |> Stream.toArray 
+                let y = xs |> Seq.scan (+) 0 |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()            
+
+        [<Test>]
+        let ``sum`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map (fun n -> 2 * n) |> Stream.sum
+                let y = xs |> Seq.map (fun n -> 2 * n) |> Seq.sum
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``length`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.filter (fun n -> n % 2 = 0) |> Stream.length
+                let y = xs |> Seq.filter (fun n -> n % 2 = 0) |> Seq.length
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``sortBy`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.map ((+) 1) |> Stream.sortBy id |> Stream.toArray
+                let y = xs |> Seq.map ((+) 1) |> Seq.sortBy id |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``minBy`` () =
+            Spec.ForAny<int[]>(fun xs -> 
+                if Array.isEmpty xs then
+                    try let _ = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1) in false
+                    with :? System.ArgumentException -> true
+                else
+                    let x = xs |> Stream.ofArray |> Stream.minBy (fun i -> i + 1)
+                    let y = xs |> Seq.minBy (fun i -> i + 1)
+                    x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``maxBy`` () =
+            Spec.ForAny<int[]>(fun xs -> 
+                if Array.isEmpty xs then 
+                    try let _ = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1) in false
+                    with :? System.ArgumentException -> true
+                else
+                    let x = xs |> Stream.ofArray |> Stream.maxBy (fun i -> i + 1)
+                    let y = xs |> Seq.maxBy (fun i -> i + 1)
+                    x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``countBy`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.countBy (fun i -> i % 5) |> Stream.toArray
+                let y = xs |> Seq.countBy (fun i -> i % 5) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``foldBy`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs 
+                        |> Stream.ofArray 
+                        |> Stream.foldBy id (fun ts t -> t :: ts) (fun () -> []) // groupBy implementation
+                        |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
+                        |> Stream.toArray
+                let y = xs  
+                        |> Seq.groupBy id 
+                        |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
+                        |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``groupBy`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs 
+                        |> Stream.ofArray 
+                        |> Stream.groupBy id  
+                        |> Stream.map (fun (key, values) -> (key, values |> Seq.length))
+                        |> Stream.toArray
+                let y = xs  
+                        |> Seq.groupBy id 
+                        |> Seq.map (fun (key, values) -> (key, values |> Seq.length))
+                        |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``take`` () =
+            Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
+                let n = System.Math.Abs(n) 
+                let x = xs |> Stream.ofArray |> Stream.take n |> Stream.length
+                let y = xs.Take(n).Count()
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``take/boundary check`` () =
+            Spec.ForAny<int>(fun (n : int) ->
+                let refs = [| 1; 2; 3; 4 |]
+                let n = System.Math.Abs(n) 
+                let x = [|1..n|]
+                        |> Stream.ofArray
+                        |> Stream.map (fun i -> refs.[i])
+                        |> Stream.take 3
+                        |> Stream.toArray
+                let y = ([|1..n|] |> Seq.map (fun i -> refs.[i])).Take(3).ToArray()
+                x = y).QuickCheckThrowOnFailure()
         
 
 
                 
-    [<Test>]
-    let ``takeWhile`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let pred = (fun value -> value % 2 = 0)
-            let x = xs |> Stream.ofArray |> Stream.takeWhile pred |> Stream.length
-            let y = xs.TakeWhile(pred).Count()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``takeWhile`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let pred = (fun value -> value % 2 = 0)
+                let x = xs |> Stream.ofArray |> Stream.takeWhile pred |> Stream.length
+                let y = xs.TakeWhile(pred).Count()
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``collect/take`` () =
-        Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
-            let n = System.Math.Abs(n) 
-            let x = xs |> Stream.ofArray |> Stream.collect(fun x -> xs |> Stream.ofArray |> Stream.take n) |> Stream.length
-            let y = xs.SelectMany(fun x -> xs.Take(n)).Count()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``collect/take`` () =
+            Spec.ForAny<int[] * int>(fun (xs, (n : int)) ->
+                let n = System.Math.Abs(n) 
+                let x = xs |> Stream.ofArray |> Stream.collect(fun x -> xs |> Stream.ofArray |> Stream.take n) |> Stream.length
+                let y = xs.SelectMany(fun x -> xs.Take(n)).Count()
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``skip`` () =
-        Spec.ForAny<int[] * int>(fun (xs, (n : int)) -> 
-            let x = xs |> Stream.ofArray |> Stream.skip n |> Stream.length
-            let y = xs.Skip(n).Count()
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``skip`` () =
+            Spec.ForAny<int[] * int>(fun (xs, (n : int)) -> 
+                let x = xs |> Stream.ofArray |> Stream.skip n |> Stream.length
+                let y = xs.Skip(n).Count()
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``tryFind`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.tryFind (fun n -> n % 2 = 0) 
-            let y = xs |> Seq.tryFind (fun n -> n % 2 = 0) 
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``tryFind`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.tryFind (fun n -> n % 2 = 0) 
+                let y = xs |> Seq.tryFind (fun n -> n % 2 = 0) 
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``find`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = try xs |> Stream.ofArray |> Stream.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
-            let y = try xs |> Seq.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``find`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = try xs |> Stream.ofArray |> Stream.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
+                let y = try xs |> Seq.find (fun n -> n % 2 = 0) with | :? KeyNotFoundException -> -1
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``tryPick`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
-            let y = xs |> Seq.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``tryPick`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
+                let y = xs |> Seq.tryPick (fun n -> if n % 2 = 0 then Some n else None) 
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``pick`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = try xs |> Stream.ofArray |> Stream.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
-            let y = try xs |> Seq.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``pick`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = try xs |> Stream.ofArray |> Stream.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
+                let y = try xs |> Seq.pick (fun n -> if n % 2 = 0 then Some n else None)  with | :? KeyNotFoundException -> -1
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``exists`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.exists (fun n -> n % 2 = 0) 
-            let y = xs |> Seq.exists (fun n -> n % 2 = 0) 
-            x = y).QuickCheckThrowOnFailure()
-
-
-    [<Test>]
-    let ``forall`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.forall (fun n -> n % 2 = 0) 
-            let y = xs |> Seq.forall (fun n -> n % 2 = 0) 
-            x = y).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``exists`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.exists (fun n -> n % 2 = 0) 
+                let y = xs |> Seq.exists (fun n -> n % 2 = 0) 
+                x = y).QuickCheckThrowOnFailure()
 
 
+        [<Test>]
+        let ``forall`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.forall (fun n -> n % 2 = 0) 
+                let y = xs |> Seq.forall (fun n -> n % 2 = 0) 
+                x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``zipWith`` () =
-        Spec.ForAny<(int[] * int[])>(fun (xs, ys) ->
-            let x = xs |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0) |> Stream.zipWith (fun x y -> x + y) (ys |> Stream.ofArray) |> Stream.toArray
-            let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.zip ys |> Seq.map (fun (x, y) -> x + y) |> Seq.toArray
-            x = y).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``empty`` () =
-        //for bulk
-        Assert.AreEqual(0, Stream.empty<int> |> Stream.length)
-        //for next
-        Assert.AreEqual(0, Stream.empty<int> |> Stream.toSeq |> Seq.length)
 
-    [<Test>]
-    let ``concat`` () =
-        Spec.ForAny<int[][]>(fun xs ->
-            let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toArray
-            let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
-            Assert.AreEqual(x, y)
-            let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toSeq |> Seq.toArray
-            let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
-            Assert.AreEqual(x, y)
+        [<Test>]
+        let ``zipWith`` () =
+            Spec.ForAny<(int[] * int[])>(fun (xs, ys) ->
+                let x = xs |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0) |> Stream.zipWith (fun x y -> x + y) (ys |> Stream.ofArray) |> Stream.toArray
+                let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.zip ys |> Seq.map (fun (x, y) -> x + y) |> Seq.toArray
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``empty`` () =
+            //for bulk
+            Assert.AreEqual(0, Stream.empty<int> |> Stream.length)
+            //for next
+            Assert.AreEqual(0, Stream.empty<int> |> Stream.toSeq |> Seq.length)
+
+        [<Test>]
+        let ``concat`` () =
+            Spec.ForAny<int[][]>(fun xs ->
+                let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toArray
+                let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
+                Assert.AreEqual(x, y)
+                let x = xs |> Seq.map (fun xs' -> xs' |> Stream.ofArray |> Stream.filter (fun x -> x % 2 = 0)) |> Stream.concat |> Stream.toSeq |> Seq.toArray
+                let y = xs |> Seq.map (fun xs' -> xs' |> Seq.filter (fun x -> x % 2 = 0)) |> Seq.concat |> Seq.toArray
+                Assert.AreEqual(x, y)
+                ).QuickCheckThrowOnFailure()
+
+
+        [<Test>]
+        let ``cast`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |>  Stream.cast |> Stream.toArray
+                let y = xs |> Seq.cast |> Seq.toArray
+                Assert.AreEqual(x, y)
+                let x = xs |>  Stream.cast |> Stream.toSeq |> Seq.length
+                let y = xs |> Seq.cast |> Seq.length
+                Assert.AreEqual(x, y)
+                ).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``cache``() =
+            Spec.ForAny<int[]>(fun xs ->
+                let x = xs |> Stream.ofArray |> Stream.cache |> Stream.toArray
+                let y = xs |> Seq.cache |> Seq.toArray
+                Assert.AreEqual(x, y)
+                let cached = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+                let cachedSeq = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+                let x' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
+                let x'' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
+                Assert.AreEqual(x', x'')
+                let y' = cachedSeq |> Seq.map (fun x -> x + 1) |> Seq.toArray
+                Assert.AreEqual(x', y')
+
+                let cached' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+                let cachedSeq' = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+
+                let count = ref 0
+                try cached' |> Stream.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
+                try cachedSeq' |> Seq.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
+                let x''' = cached' |> Stream.map (fun x -> x + 1) |> Stream.toArray
+                let y''' = cachedSeq' |> Seq.map (fun x -> x + 1) |> Seq.toArray
+                Assert.AreEqual(x''', y''')
+                Assert.AreEqual(x''', x'')
+
+                let cached'' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
+                let x4 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toSeq |> Seq.toArray
+                let x5 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toArray
+                Assert.AreEqual(x4, x5)
+                ).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``groupUntil``() =
+            Spec.ForAny<int []>(fun xs ->
+                // push-based tests
+                let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toArray |> Array.concat
+                Assert.AreEqual(xs, ys)
+                let failedPredicates = ref 0
+                let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toArray |> Seq.concat |> Seq.length
+                Assert.AreEqual(xs.Length, ys + !failedPredicates)
+                // pull-based tests
+                let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toSeq |> Array.concat
+                Assert.AreEqual(xs, ys)
+                let failedPredicates = ref 0
+                let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toSeq |> Seq.concat |> Seq.length
+                Assert.AreEqual(xs.Length, ys + !failedPredicates)
             ).QuickCheckThrowOnFailure()
 
 
-    [<Test>]
-    let ``cast`` () =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |>  Stream.cast |> Stream.toArray
-            let y = xs |> Seq.cast |> Seq.toArray
-            Assert.AreEqual(x, y)
-            let x = xs |>  Stream.cast |> Stream.toSeq |> Seq.length
-            let y = xs |> Seq.cast |> Seq.length
-            Assert.AreEqual(x, y)
-            ).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``seq/dispose``() =
+            let disposed = ref false
+            let testEnumerator (array : int []) = 
+                disposed := false
+                let index = ref -1
+                {   new IEnumerator<int> with
+                        member self.Current = array.[!index]
+                    interface System.Collections.IEnumerator with  
+                        member self.Current = box array.[!index]
+                        member self.MoveNext() = 
+                            incr index
+                            if !index >= array.Length then false else true
+                        member self.Reset() = index := -1 
+                    interface System.IDisposable with  
+                        member self.Dispose() = disposed := true }
+            let testEnumerable (array : int []) = 
+                {   new IEnumerable<int> with
+                        member self.GetEnumerator() = testEnumerator array
+                    interface System.Collections.IEnumerable with
+                        member self.GetEnumerator() = testEnumerator array :> _ }
+            Spec.ForAny<int []>(fun xs -> 
+                let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
+                let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
+                x = y && !disposed = true).QuickCheckThrowOnFailure()
 
-    [<Test>]
-    let ``cache``() =
-        Spec.ForAny<int[]>(fun xs ->
-            let x = xs |> Stream.ofArray |> Stream.cache |> Stream.toArray
-            let y = xs |> Seq.cache |> Seq.toArray
-            Assert.AreEqual(x, y)
-            let cached = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-            let cachedSeq = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
-            let x' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
-            let x'' = cached |> Stream.map (fun x -> x + 1) |> Stream.toArray
-            Assert.AreEqual(x', x'')
-            let y' = cachedSeq |> Seq.map (fun x -> x + 1) |> Seq.toArray
-            Assert.AreEqual(x', y')
+        [<Test>]
+        let ``head``() =
+            Spec.ForAny<int []>(fun (xs : int []) ->
+                let x =
+                    try xs |> Stream.ofArray |> Stream.head
+                    with :? System.ArgumentException -> -1
 
-            let cached' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-            let cachedSeq' = xs |> Seq.filter(fun x -> x % 2 = 0) |> Seq.cache
+                let y =
+                    try xs |> Seq.head
+                    with :? System.ArgumentException -> -1
 
-            let count = ref 0
-            try cached' |> Stream.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
-            try cachedSeq' |> Seq.map (fun v -> (if !count = 1 then failwith "OOPS"); incr count; v) |> ignore with _ -> ()
-            let x''' = cached' |> Stream.map (fun x -> x + 1) |> Stream.toArray
-            let y''' = cachedSeq' |> Seq.map (fun x -> x + 1) |> Seq.toArray
-            Assert.AreEqual(x''', y''')
-            Assert.AreEqual(x''', x'')
+                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
-            let cached'' = xs |> Stream.ofArray |> Stream.filter(fun x -> x % 2 = 0) |> Stream.cache
-            let x4 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toSeq |> Seq.toArray
-            let x5 = cached'' |> Stream.map (fun v -> v + 1) |> Stream.toArray
-            Assert.AreEqual(x4, x5)
-            ).QuickCheckThrowOnFailure()
+        [<Test>]
+        let ``tryHead``() =
+            Spec.ForAny<int []>(fun (xs : int []) ->
+                let x = xs |> Stream.ofArray |> Stream.tryHead
+                let y =
+                    try Some (xs |> Seq.head)
+                    with :? System.ArgumentException -> None
 
-    [<Test>]
-    let ``groupUntil``() =
-        Spec.ForAny<int []>(fun xs ->
-            // push-based tests
-            let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toArray |> Array.concat
-            Assert.AreEqual(xs, ys)
-            let failedPredicates = ref 0
-            let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toArray |> Seq.concat |> Seq.length
-            Assert.AreEqual(xs.Length, ys + !failedPredicates)
-            // pull-based tests
-            let ys = xs |> Stream.ofArray |> Stream.groupUntil true (fun i -> i % 7 <> 0) |> Stream.toSeq |> Array.concat
-            Assert.AreEqual(xs, ys)
-            let failedPredicates = ref 0
-            let ys = xs |> Stream.ofArray |> Stream.groupUntil false (fun i -> if i % 7 <> 0 then true else incr failedPredicates ; false) |> Stream.toSeq |> Seq.concat |> Seq.length
-            Assert.AreEqual(xs.Length, ys + !failedPredicates)
-        ).QuickCheckThrowOnFailure()
+                Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
+        [<Test>]
+        let ``isEmpty``() =
+            Spec.ForAny<int []>(fun (xs : int  []) ->
+                let x = xs |> Stream.ofArray |> Stream.isEmpty
+                let y = xs |> Array.isEmpty
 
-    [<Test>]
-    let ``seq/dispose``() =
-        let disposed = ref false
-        let testEnumerator (array : int []) = 
-            disposed := false
-            let index = ref -1
-            {   new IEnumerator<int> with
-                    member self.Current = array.[!index]
-                interface System.Collections.IEnumerator with  
-                    member self.Current = box array.[!index]
-                    member self.MoveNext() = 
-                        incr index
-                        if !index >= array.Length then false else true
-                    member self.Reset() = index := -1 
-                interface System.IDisposable with  
-                    member self.Dispose() = disposed := true }
-        let testEnumerable (array : int []) = 
-            {   new IEnumerable<int> with
-                    member self.GetEnumerator() = testEnumerator array
-                interface System.Collections.IEnumerable with
-                    member self.GetEnumerator() = testEnumerator array :> _ }
-        Spec.ForAny<int []>(fun xs -> 
-            let x = xs |> testEnumerable |> Stream.ofSeq |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.length
-            let y = xs |> Seq.filter (fun x -> x % 2 = 0) |> Seq.map ((+)1) |> Seq.length 
-            x = y && !disposed = true).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``head``() =
-        Spec.ForAny<int []>(fun (xs : int []) ->
-            let x =
-                try xs |> Stream.ofArray |> Stream.head
-                with :? System.ArgumentException -> -1
-
-            let y =
-                try xs |> Seq.head
-                with :? System.ArgumentException -> -1
-
-            Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
-
-    [<Test>]
-    let ``tryHead``() =
-        Spec.ForAny<int []>(fun (xs : int []) ->
-            let x = xs |> Stream.ofArray |> Stream.tryHead
-            let y =
-                try Some (xs |> Seq.head)
-                with :? System.ArgumentException -> None
-
-            Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
-
-(*
-    [<Test>]
-    let ``isEmpty``() =
-        Spec.ForAny<int []>(fun (xs : int  []) ->
-            let x = xs |> Stream.ofArray |> Stream.isEmpty
-            let y = xs |> Array.isEmpty
-
-            Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
-*)
+                Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
 
 module PerfTests = 
   let AdhocPerformanceTest() = 

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -420,7 +420,6 @@ module ``Streams tests``  =
 
                 Assert.AreEqual(y, x)).QuickCheckThrowOnFailure()
 
-(*
         [<Test>]
         let ``isEmpty``() =
             Spec.ForAny<int []>(fun (xs : int  []) ->
@@ -428,7 +427,6 @@ module ``Streams tests``  =
                 let y = xs |> Array.isEmpty
 
                 Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
-*)
 
 module PerfTests = 
   let AdhocPerformanceTest() = 
@@ -505,37 +503,22 @@ module PerfTests =
     runList() |> ignore
     runStream() |> ignore
       //0.3.0: 
-      // Real: 00:00:03.696, CPU: 00:00:03.671, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:03.519, CPU: 00:00:03.515, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:04.427, CPU: 00:00:04.406, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.735, CPU: 00:00:02.718, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:03.358, CPU: 00:00:03.359, GC gen0: 0, gen1: 0, gen2: 0
-      // New (with inlining)
-      // Real: 00:00:03.893, CPU: 00:00:03.906, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.672, CPU: 00:00:02.625, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:03.298, CPU: 00:00:03.296, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.859, CPU: 00:00:02.859, GC gen0: 1, gen1: 0, gen2: 0
-      // Real: 00:00:03.102, CPU: 00:00:03.093, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:04.127, CPU: 00:00:04.093, GC gen0: 0, gen1: 0, gen2: 0
-      // New (without inlining)
-      // Real: 00:00:17.211, CPU: 00:00:16.937, GC gen0: 1, gen1: 0, gen2: 0
-      // Real: 00:00:17.750, CPU: 00:00:17.687, GC gen0: 0, gen1: 0, gen2: 0
-      // New (with inlining and Stream as record)
-      // Real: 00:00:02.411, CPU: 00:00:02.390, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.487, CPU: 00:00:02.468, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.428, CPU: 00:00:02.437, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.465, CPU: 00:00:02.468, GC gen0: 1, gen1: 0, gen2: 0
-      // Real: 00:00:02.495, CPU: 00:00:02.484, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.853, CPU: 00:00:02.859, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:03.276, CPU: 00:00:03.234, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.757, CPU: 00:00:02.718, GC gen0: 0, gen1: 0, gen2: 0
-      // New (without inlining but map partially inlined)
-      // Real: 00:00:08.328, CPU: 00:00:08.250, GC gen0: 0, gen1: 0, gen2: 0
-      // New (fully hidden represenations)
-      // Real: 00:00:02.980, CPU: 00:00:02.968, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.961, CPU: 00:00:02.953, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:03.009, CPU: 00:00:03.015, GC gen0: 0, gen1: 0, gen2: 0
-      // Real: 00:00:02.952, CPU: 00:00:02.921, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:03.352, CPU: 00:00:03.343, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:02.631, CPU: 00:00:02.640, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:02.858, CPU: 00:00:02.843, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:03.156, CPU: 00:00:03.156, GC gen0: 0, gen1: 0, gen2: 0
+      //
+      //New (fully hidden represenations, without any inlining)
+      //   Real: 00:00:17.211, CPU: 00:00:16.937, GC gen0: 1, gen1: 0, gen2: 0
+      //   Real: 00:00:17.750, CPU: 00:00:17.687, GC gen0: 0, gen1: 0, gen2: 0
+      //
+      //New (fully hidden represenations, with inlining reducing to Internals)
+      //   Real: 00:00:02.980, CPU: 00:00:02.968, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:02.961, CPU: 00:00:02.953, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:03.009, CPU: 00:00:03.015, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:02.952, CPU: 00:00:02.921, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:03.812, CPU: 00:00:03.796, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:03.483, CPU: 00:00:03.484, GC gen0: 0, gen1: 0, gen2: 0
 
 
 

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -480,8 +480,8 @@ module PerfTests =
         |> Array.filter (fun x -> x % 2 = 0)
         |> Array.length
 
-    let runStream() =
-     for i in 0 .. 100 do
+    let runStream n =
+     for i in 1 .. n do
         xs 
         |> Stream.ofArray
         |> Stream.take 1000000
@@ -501,7 +501,7 @@ module PerfTests =
 
     runSeq() |> ignore
     runList() |> ignore
-    runStream() |> ignore
+    runStream 100 |> ignore
       //0.3.0: 
       //   Real: 00:00:03.352, CPU: 00:00:03.343, GC gen0: 0, gen1: 0, gen2: 0
       //   Real: 00:00:02.631, CPU: 00:00:02.640, GC gen0: 0, gen1: 0, gen2: 0
@@ -513,12 +513,9 @@ module PerfTests =
       //   Real: 00:00:17.750, CPU: 00:00:17.687, GC gen0: 0, gen1: 0, gen2: 0
       //
       //New (fully hidden represenations, with inlining reducing to Internals)
-      //   Real: 00:00:02.980, CPU: 00:00:02.968, GC gen0: 0, gen1: 0, gen2: 0
-      //   Real: 00:00:02.961, CPU: 00:00:02.953, GC gen0: 0, gen1: 0, gen2: 0
-      //   Real: 00:00:03.009, CPU: 00:00:03.015, GC gen0: 0, gen1: 0, gen2: 0
-      //   Real: 00:00:02.952, CPU: 00:00:02.921, GC gen0: 0, gen1: 0, gen2: 0
-      //   Real: 00:00:03.812, CPU: 00:00:03.796, GC gen0: 0, gen1: 0, gen2: 0
-      //   Real: 00:00:03.483, CPU: 00:00:03.484, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:02.384, CPU: 00:00:02.375, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:02.490, CPU: 00:00:02.484, GC gen0: 0, gen1: 0, gen2: 0
+      //   Real: 00:00:02.362, CPU: 00:00:02.343, GC gen0: 0, gen1: 0, gen2: 0
 
 
 


### PR DESCRIPTION
I've looked into what it would take to internalize the representations of streams while keeping performance where code is well inlined and at least as much fusing occurs as today.

The aim is to put this library on a sustainable binary-compatible basis while keeping performance.  

The PR is an extension of #30 which should be merged first - when that is done the diff below will reduce

The formulation I've used below seems to work

- All the primary functions such as "map", "fold", "scan" and "iter" boil down to three public functions in a Internals module called mapCont, mapContCancel and iterCancel.  These functions are public but not for direct use - they leak a few representations details such as the use of a continuation to sink results and the use of CancellationToken to cancel.  However crucially they don't leak the representation details or Stream, Context, Iterable or Iterator.  I would expect these functions to be implementable no matter what future changes we make to the representation of the Stream, Context, Iterable and Iterator types.

- Some care is taken to avoid partial applications in a couple of situations, see `nocurry()`

It would be very cool if we could somehow find a way to fully fuse map --> map --> map --> map chains, however I haven't been able to do that, I don't think it's possible with F# 4.0's optimizer, even when we fully leak all representations.


