### PR TITLE
Remove index in ParStream

### DIFF
--- a/src/Streams.Core/ParStreams.fs
+++ b/src/Streams.Core/ParStreams.fs
@@ -380,17 +380,20 @@ module ParStream =
     /// <param name="f">A function to apply to each element of the parallel stream.</param>
     /// <param name="stream">The input parallel stream.</param>    
     let inline iter (f : 'T -> unit) (stream : ParStream<'T>) : unit = 
-        let collector = 
-            { new Collector<'T, obj> with
-                member self.DegreeOfParallelism = stream.DegreeOfParallelism
-                member self.Iterator() = 
-                    { Index = ref -1; 
-                      Func = (fun value -> f value);
-                      Cts = new CancellationTokenSource() }
-                member self.Result = 
-                    () :> _ }
+        if stream.PreserveOrdering then 
+            stream.Stream() |> Stream.iter f 
+        else
+            let collector = 
+                { new Collector<'T, obj> with
+                    member self.DegreeOfParallelism = stream.DegreeOfParallelism
+                    member self.Iterator() = 
+                        { Index = ref -1; 
+                          Func = (fun value -> f value);
+                          Cts = new CancellationTokenSource() }
+                    member self.Result = 
+                        () :> _ }
 
-        stream.Apply collector |> ignore
+            stream.Apply collector |> ignore
 
     /// <summary>Applies a function to each element of the parallel stream, threading an accumulator argument through the computation. If the input function is f and the elements are i0...iN, then this function computes f (... (f s i0)...) iN.</summary>
     /// <param name="folder">A function that updates the state with each element from the parallel stream.</param>
@@ -421,7 +424,7 @@ module ParStream =
             match stream.SourceType with
             | SourceType.Array | SourceType.ResizeArray -> stream.Stream() |> Stream.fold folder (state())
             | SourceType.Seq -> 
-                let stream = stream.Stream() |> Stream.toSeq |> ofSeq |> withDegreeOfParallelism stream.DegreeOfParallelism 
+                let stream = unordered stream
                 stream.Apply collector
         else 
             stream.Apply collector
@@ -652,7 +655,7 @@ module ParStream =
                 member self.Result = 
                     !resultRef }
         
-        let stream = if stream.PreserveOrdering then stream.Stream() |> Stream.toSeq |> ofSeq |> withDegreeOfParallelism stream.DegreeOfParallelism else stream
+        let stream = unordered stream
         stream.Apply collector
 
     /// <summary>Returns the first element for which the given function returns true. Raises KeyNotFoundException if no such element exists.</summary>
@@ -682,7 +685,7 @@ module ParStream =
                 member self.Result = 
                     !resultRef }
 
-        let stream = if stream.PreserveOrdering then stream.Stream() |> Stream.toSeq |> ofSeq |> withDegreeOfParallelism stream.DegreeOfParallelism else stream
+        let stream = unordered stream
         stream.Apply collector
 
 

--- a/tests/Streams.Tests/ParStreamsTests.fs
+++ b/tests/Streams.Tests/ParStreamsTests.fs
@@ -1,15 +1,24 @@
-﻿namespace Nessos.Streams.Tests
-    open System.Linq
-    open System.Threading
-    open System.Collections.Generic
-    open FsCheck
-    open FsCheck.Fluent
-    open NUnit.Framework
-    open FSharp.Collections.ParallelSeq
-    open Nessos.Streams
+﻿#if INTERACTIVE
+#r @"../../bin/Streams.Core.dll"
+//#r @"../../packages/Streams.0.3.0/lib/net45/Streams.Core.dll"
+#r @"../../packages/NUnit.3.0.0-alpha/lib/net45/nunit.framework.dll"
+#r @"../../packages/FsCheck.1.0.1/lib/net45/FSCheck.dll"
+#time "on"
+#else
+namespace Nessos.Streams.Tests
+#endif
 
-    [<TestFixture; Category("ParStreams.FSharp")>]
-    type ``ParStreams tests`` () =
+open System.Linq
+open System.Threading
+open System.Collections.Generic
+open FsCheck
+open FsCheck.Fluent
+open NUnit.Framework
+open FSharp.Collections.ParallelSeq
+open Nessos.Streams
+
+[<TestFixture; Category("ParStreams.FSharp")>]
+type ``ParStreams tests`` () =
 
         [<OneTimeSetUp>]
         member __.SetUp() =
@@ -324,3 +333,18 @@
                 let y = xs |> Stream.ofArray |> Stream.isEmpty
 
                 Assert.AreEqual(x, y)).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        member __.``mapi/filter``() =
+            Spec.ForAny<int []>(fun (xs : int  []) ->
+                let x = 
+                    let ra = ResizeArray()
+                    ParStream.ofArray xs |> ParStream.filter (fun x -> x % 2 = 0) |> ParStream.mapi (fun i x -> (i,x)) |> ParStream.iter ra.Add
+                    ra.ToArray()
+                let y = 
+                    let ra = ResizeArray()
+                    Stream.ofArray xs |> Stream.filter (fun x -> x % 2 = 0) |> Stream.mapi (fun i x -> (i,x)) |> Stream.iter ra.Add
+                    ra.ToArray()
+
+                x = y).QuickCheckThrowOnFailure()
+


### PR DESCRIPTION
This extends the fix for #36  in #37  to remove the "Index" in the parallel stream iterators, since it is kind of broken for "mapi".

In more detail, the Index reference cell is only consumed by mapi.  However it gives incorrect results if preceded by something which changes the index ordering, e.g. a filter.  It seems "Apply" really shouldn't be called for an ordered sequence anyway, so the best approach seems to be to just remove the whole attempt to keep track of Index an instead call "unordered" first in the case of using Apply on a ParStream.mapi (which never happens via internal calls, but may happen via an external caller to Apply)
