### PR TITLE
Added infinite stream generation

### DIFF
--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -42,7 +42,7 @@ module ``Streams tests``  =
         let ``infinite`` () =
             Spec.ForAny<int[]>(fun xs ->
                 // we use modulus here to keep the runtime sane.
-                let sumTo v= (fun _ -> 1) |> Stream.infinite |> Stream.toSeq |> Seq.take (abs(v) % 100) |> Seq.sum
+                let sumTo v= (fun _ -> 1) |> Stream.infinite |> Stream.take (abs(v) % 100) |> Stream.sum
                 let x = Array.map sumTo xs
                 let y = Array.map (fun v -> abs(v) % 100) xs
                 x = y).QuickCheckThrowOnFailure()

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -42,7 +42,7 @@ module ``Streams tests``  =
         let ``infinite`` () =
             Spec.ForAny<int[]>(fun xs ->
                 // we use modulus here to keep the runtime sane.
-                let sumTo v= (fun _ -> 1) |> Stream.infinite |> Stream.take (abs(v) % 100) |> Stream.sum
+                let sumTo v= (fun _ -> 1) |> Stream.infinite |> Stream.toSeq |> Seq.take (abs(v) % 100) |> Seq.sum
                 let x = Array.map sumTo xs
                 let y = Array.map (fun v -> abs(v) % 100) xs
                 x = y).QuickCheckThrowOnFailure()

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -41,7 +41,7 @@ module ``Streams tests``  =
         [<Test>]
         let ``generateInfinite`` () =
             Spec.ForAny<int[]>(fun xs ->
-                // we use modulus here to keep the runtime sane.
+                // we use modulus here to keep the test duration somewhat short.
                 let sumTo v= (fun _ -> 1) |> Stream.generateInfinite |> Stream.toSeq |> Seq.take (abs(v) % 100) |> Seq.sum
                 let x = Array.map sumTo xs
                 let y = Array.map (fun v -> abs(v) % 100) xs
@@ -50,7 +50,6 @@ module ``Streams tests``  =
         [<Test>]
         let ``initInfinite`` () =
             Spec.ForAny<int[]>(fun (xs:int[]) ->
-                // we use modulus here to keep the runtime sane.
                 let x = (fun i -> xs.[i]) |> Stream.initInfinite |> Stream.toSeq |> Seq.take xs.Length |> Array.ofSeq
                 let y = xs
                 x = y).QuickCheckThrowOnFailure()

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -39,6 +39,15 @@ module ``Streams tests``  =
                 x = y).QuickCheckThrowOnFailure()
 
         [<Test>]
+        let ``infinite`` () =
+            Spec.ForAny<int[]>(fun xs ->
+                // we use modulus here to keep the runtime sane.
+                let sumTo v= (fun _ -> 1) |> Stream.infinite |> Stream.toSeq |> Seq.take (abs(v) % 100) |> Seq.sum
+                let x = Array.map sumTo xs
+                let y = Array.map (fun v -> abs(v) % 100) xs
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
         let ``toSeq`` () =
             Spec.ForAny<int[]>(fun xs ->
                 let x = xs |> Stream.ofArray |> Stream.flatMap (fun _ -> Stream.ofArray xs) |> Stream.filter (fun x -> x % 2 = 0) |> Stream.map ((+)1) |> Stream.toSeq |> Seq.toArray

--- a/tests/Streams.Tests/StreamsTests.fs
+++ b/tests/Streams.Tests/StreamsTests.fs
@@ -39,12 +39,20 @@ module ``Streams tests``  =
                 x = y).QuickCheckThrowOnFailure()
 
         [<Test>]
-        let ``infinite`` () =
+        let ``generateInfinite`` () =
             Spec.ForAny<int[]>(fun xs ->
                 // we use modulus here to keep the runtime sane.
-                let sumTo v= (fun _ -> 1) |> Stream.infinite |> Stream.toSeq |> Seq.take (abs(v) % 100) |> Seq.sum
+                let sumTo v= (fun _ -> 1) |> Stream.generateInfinite |> Stream.toSeq |> Seq.take (abs(v) % 100) |> Seq.sum
                 let x = Array.map sumTo xs
                 let y = Array.map (fun v -> abs(v) % 100) xs
+                x = y).QuickCheckThrowOnFailure()
+
+        [<Test>]
+        let ``initInfinite`` () =
+            Spec.ForAny<int[]>(fun (xs:int[]) ->
+                // we use modulus here to keep the runtime sane.
+                let x = (fun i -> xs.[i]) |> Stream.initInfinite |> Stream.toSeq |> Seq.take xs.Length |> Array.ofSeq
+                let y = xs
                 x = y).QuickCheckThrowOnFailure()
 
         [<Test>]


### PR DESCRIPTION
This allows for the creation of infinite streams from a generator function of (Unit -> 'T).

I'm not really sure how to write a test for this, because, well... it's infinite.

Here's the code I used to test and benchmark my implementation vs Stream.ofSeq

```fsharp
open Nessos.Streams
open System
open System.Diagnostics

[<EntryPoint>]
let main argv = 
    let sw = Stopwatch()
    do sw.Start()
    let counter = ref 0
    let incrCounter() = counter.Value <- counter.Value + 1
    
    let count (f : 'a -> unit) x = 
        incrCounter()
        if (sw.ElapsedMilliseconds >= 1000L) then 
            printfn "processed %d items in 1 second!" (counter.Value)
            counter.Value <- 0
            sw.Restart()
        f x
    
    let benchmark = count (ignore)
    
    let infiniteFromSeq() = 
        seq { 
            while true do
                yield DateTime.Now
        }
        |> Stream.ofSeq
        |> Stream.iter (benchmark)
    
    let infiniteFromStream() = Stream.infinite (fun _ -> DateTime.UtcNow) |> Stream.iter (benchmark)
    //
    // //perform the measurements:
    // infiniteFromSeq()
    // 9.5 million items per second
    // ----------
    infiniteFromStream()
    // 15.5 million items per second
    // ----------
    0 


```


Using Stream.ofSeq on an infinite sequence generated using a while loop:
~9.5 million items per second
using the new infinite Stream instead:
~15.5 million items per second

This is a significant speedup, and would probably benefit anyone using an infinite stream.